### PR TITLE
Release 6.0.0

### DIFF
--- a/interrupt_schedule_off.php
+++ b/interrupt_schedule_off.php
@@ -1,0 +1,8 @@
+<?php
+include_once "/opt/fpp/www/common.php";
+$pluginName = "remote-falcon";
+
+WriteSettingToFile("interrupt_schedule_enabled",urlencode("false"),$pluginName);
+WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
+WriteSettingToFile("remote_fpp_restarting",urlencode("true"),$pluginName);
+?>

--- a/interrupt_schedule_on.php
+++ b/interrupt_schedule_on.php
@@ -1,0 +1,8 @@
+<?php
+include_once "/opt/fpp/www/common.php";
+$pluginName = "remote-falcon";
+
+WriteSettingToFile("interrupt_schedule_enabled",urlencode("true"),$pluginName);
+WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
+WriteSettingToFile("remote_fpp_restarting",urlencode("true"),$pluginName);
+?>

--- a/purge_queue.php
+++ b/purge_queue.php
@@ -1,0 +1,23 @@
+<?php
+include_once "/opt/fpp/www/common.php";
+include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";
+$baseUrl = getBaseUrl();
+$pluginConfigFile = $settings['configDirectory'] . "/plugin.remote-falcon";
+$pluginSettings = parse_ini_file($pluginConfigFile);
+
+$remoteToken = urldecode($pluginSettings['remoteToken']);
+
+if(strlen($remoteToken)>1) {
+	$url = $baseUrl . "/remotefalcon/api/purgeQueue";
+	$options = array(
+		'http' => array(
+		'method'  => 'DELETE',
+		'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
+					"Accept: application/json\r\n" .
+					"remotetoken: $remoteToken\r\n"
+		)
+	);
+	$context = stream_context_create( $options );
+	$result = file_get_contents( $url, false, $context );
+}
+?>

--- a/remote_falcon.php
+++ b/remote_falcon.php
@@ -2,7 +2,7 @@
 include_once "/opt/fpp/www/common.php";
 include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";
 $baseUrl = getBaseUrl();
-$rfSequencesUrl = $baseUiUrl . "/controlPanel/sequences";
+$rfSequencesUrl = $baseUrl . "/controlPanel/sequences";
 $pluginName = basename(dirname(__FILE__));
 $pluginConfigFile = $settings['configDirectory'] ."/plugin." .$pluginName;
     

--- a/remote_falcon.php
+++ b/remote_falcon.php
@@ -1,212 +1,192 @@
 <?php
-include_once "/opt/fpp/www/common.php"; //Alows use of FPP Functions
+include_once "/opt/fpp/www/common.php";
 include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";
 $baseUrl = getBaseUrl();
+$rfSequencesUrl = $baseUiUrl . "/controlPanel/sequences";
 $pluginName = basename(dirname(__FILE__));
-$pluginConfigFile = $settings['configDirectory'] ."/plugin." .$pluginName; //gets path to configuration files for plugin
+$pluginConfigFile = $settings['configDirectory'] ."/plugin." .$pluginName;
     
 if (file_exists($pluginConfigFile)) {
-	$pluginSettings = parse_ini_file($pluginConfigFile);
+  $pluginSettings = parse_ini_file($pluginConfigFile);
 }
 
 if (!file_exists("/home/fpp/media/scripts/viewer_control_on.php")){
-	copy("/home/fpp/media/plugins/remote-falcon/viewer_control_on.php", "/home/fpp/media/scripts/viewer_control_on.php");
+  copy("/home/fpp/media/plugins/remote-falcon/viewer_control_on.php", "/home/fpp/media/scripts/viewer_control_on.php");
 }
 if (!file_exists("/home/fpp/media/scripts/viewer_control_off.php")){
-	copy("/home/fpp/media/plugins/remote-falcon/viewer_control_off.php", "/home/fpp/media/scripts/viewer_control_off.php");
+  copy("/home/fpp/media/plugins/remote-falcon/viewer_control_off.php", "/home/fpp/media/scripts/viewer_control_off.php");
+}
+if (!file_exists("/home/fpp/media/scripts/purge_queue.php")){
+  copy("/home/fpp/media/plugins/remote-falcon/purge_queue.php", "/home/fpp/media/scripts/purge_queue.php");
 }
 
-$pluginVersion = "5.1.7";
-
-//foreach below will read all of the settings and thier values instead of reading each one individually
-//settings saved are:
-//remote_fpp_enabled
-//interrupt_schedule_enabled
-//pluginVersion
-//remotePlaylist
-//remoteToken
+$pluginVersion = "6.0.0";
 
 //set defaults if nothing saved
 if (strlen(urldecode($pluginSettings['remotePlaylist']))<1){
-	WriteSettingToFile("remotePlaylist",urlencode(""),$pluginName);
+  WriteSettingToFile("remotePlaylist",urlencode(""),$pluginName);
 }
 if (strlen(urldecode($pluginSettings['interrupt_schedule_enabled']))<1){
-	WriteSettingToFile("interrupt_schedule_enabled",urlencode("false"),$pluginName);
-}
-if (strlen(urldecode($pluginSettings['remote_fpp_enabled']))<1){
-	WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
+  WriteSettingToFile("interrupt_schedule_enabled",urlencode("false"),$pluginName);
 }
 if (strlen(urldecode($pluginSettings['remoteToken']))<1){
-	WriteSettingToFile("remoteToken",urlencode(""),$pluginName);
+  WriteSettingToFile("remoteToken",urlencode(""),$pluginName);
+}
+if (strlen(urldecode($pluginSettings['requestFetchTime']))<1){
+  WriteSettingToFile("requestFetchTime",urlencode("10"),$pluginName);
 }
 WriteSettingToFile("pluginVersion",urlencode($pluginVersion),$pluginName);
 
 foreach ($pluginSettings as $key => $value) { 
-	${$key} = urldecode($value);
-}
-
-$remotePlaylistStyle="";
-if(strlen($remotePlaylist)<1){
-	$remotePlaylist= "NO PLAYLIST CURRENTLY SAVED";
-	$remotePlaylistStyle="color: #ff0000";
-}
-
-$playlistDirectory= $settings['playlistDirectory'];
-$playlists = "";
-
-$url = "http://127.0.0.1/api/playlists";
-$options = array(
-	'http' => array(
-		'method'  => 'GET'
-		)
-);
-
-if (is_dir($playlistDirectory)){
-	$playlistDropdown=array();
-	$playlistDropdown[""]="";
-	if ($dirTemp = opendir($playlistDirectory)){
-		while (($fileRead = readdir($dirTemp)) !== false){
-			if (($fileRead == ".") || ($fileRead == "..")){
-				continue;
-			}
-			$fileRead=pathinfo($fileRead, PATHINFO_FILENAME);
-			$playlistDropdown[$fileRead]=$fileRead;
-		}
-	  closedir($dirTemp);
-	}
+  ${$key} = urldecode($value);
 }
 
 $url = "http://127.0.0.1/api/plugin/remote-falcon/updates";
 $options = array(
-	'http' => array(
-		'method'  => 'POST',
-		'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
-								"Accept: application/json\r\n"
-		)
+  'http' => array(
+    'method'  => 'POST',
+    'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
+                "Accept: application/json\r\n"
+    )
 );
 $context = stream_context_create( $options );
 $result = file_get_contents( $url, false, $context );
 $response = json_decode( $result, true );
-if ($response['updatesAvailable'] == 1) {//show/hide the updates available section
-	$showUpdateDiv= "display:block";
+if ($response['updatesAvailable'] == 1) {
+  $showUpdateDiv = "display:block";
 }else{
-	$showUpdateDiv= "display:none";
-}
-$syncResultDiv= "display:none";
-$syncResultMessage="";
-
-if(strlen($remoteToken) > 1) {
-	//Get Response Times
-	$startTime = microtime(true);
-	$url = $baseUrl . "/remotefalcon/api/apiTest";
-	$options = array(
-		'http' => array(
-		'method'  => 'GET',
-		'header'=>  "remotetoken: $remoteToken\r\n"
-		)
-	);
-	$context = stream_context_create( $options );
-	$result = file_get_contents( $url, false, $context );
-	$responseCode = getHttpCode($http_response_header);
-	$endTime = microtime(true);
-	$responseTime = intval(($endTime - $startTime)*100);
-	$responseTimeMessage = "Remote Falcon responded in  " . $responseTime . "ms with a response code of " . $responseCode;
-
-	//Validate Token
-	$url = $GLOBALS['baseUrl'] . "/remotefalcon/api/isValidRemoteToken";
-	$options = array(
-		'http' => array(
-		'method'  => 'GET',
-		'header'=>  "remotetoken: $remoteToken\r\n"
-		)
-	);
-	$context = stream_context_create( $options );
-	$result = file_get_contents( $url, false, $context );
-	$response = json_decode( $result );
-	$isRemoteTokenValid = $response->isValidRemoteToken;
-	$validTokenMessage = "";
-	if(!$isRemoteTokenValid) {
-		$validTokenMessage = "The Remote Token entered is not valid!";
-	}
+  $showUpdateDiv = "display:none";
 }
 
-function getHttpCode($http_response_header) {
-    if(is_array($http_response_header)) {
-        $parts=explode(' ',$http_response_header[0]);
-        if(count($parts)>1)
-            return intval($parts[1]);
+$playlistDirectory= $settings['playlistDirectory'];
+$playlistOptions = "";
+if(is_dir($playlistDirectory)) {
+  if ($dirTemp = opendir($playlistDirectory)){
+    while (($fileRead = readdir($dirTemp)) !== false) {
+      if (($fileRead == ".") || ($fileRead == "..")){
+        continue;
+      }
+      $fileRead = pathinfo($fileRead, PATHINFO_FILENAME);
+      $playlistOptions .= "<option value=\"{$fileRead}\">{$fileRead}</option>";
     }
-    return 0;
+    closedir($dirTemp);
+  }
 }
 
-if (isset($_POST['saveRemotePlaylist'])) { 
-	$remotePlaylist=urldecode($pluginSettings['remotePlaylist']);
-	if (strlen($remotePlaylist)>=2){
-		if(strlen($remoteToken)>1) {
-			$playlists = array();
-			$remotePlaylistEncoded = rawurlencode($remotePlaylist);
-			$url = "http://127.0.0.1/api/playlist/${remotePlaylistEncoded}";
-			$options = array(
-				'http' => array(
-					'method'  => 'GET'
-					)
-			);
-			$context = stream_context_create( $options );
-			$result = file_get_contents( $url, false, $context );
-			$response = json_decode( $result, true );
-			$mainPlaylist = $response['mainPlaylist'];
-			$index = 1;
-			foreach($mainPlaylist as $item) {
-				if($item['type'] == 'both' || $item['type'] == 'sequence') {
-					$playlist = null;
-					$playlist->playlistName = pathinfo($item['sequenceName'], PATHINFO_FILENAME);
-					$playlist->playlistDuration = $item['duration'];
-					$playlist->playlistIndex = $index;
-					array_push($playlists, $playlist);
-				}else if($item['type'] == 'media') {
-					$playlist = null;
-					$playlist->playlistName = pathinfo($item['mediaName'], PATHINFO_FILENAME);
-					$playlist->playlistDuration = $item['duration'];
-					$playlist->playlistIndex = $index;
-					array_push($playlists, $playlist);
-				}
-				$index++;
-			}
-			$url = $baseUrl . "/remotefalcon/api/syncPlaylists";
-			$data = array(
-				'playlists' => $playlists
-			);
-			$options = array(
-				'http' => array(
-					'method'  => 'POST',
-					'content' => json_encode( $data ),
-					'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
-											"Accept: application/json\r\n" .
-											"remotetoken: $remoteToken\r\n"
-					)
-			);
-			$context = stream_context_create( $options );
-			$result = file_get_contents( $url, false, $context );
-			$response = json_decode( $result );
-			if($response) { //Sync sucess maybe get response from server on valid Playlist
-				$syncResultDiv= "color: #D65A31; display:block;";
-				$syncResultMessage= "Playlist successfully synced!";
-					
-			}else { //sync failure- maybe get server to respond with more info like invalid token, empty playlist etc?
-				$syncResultMessage= "There was an error synching your playlist! <br />Make sure you have the correct token";
-				$syncResultDiv= "color: #ff0000; display:block; background-color: black;";
-				WriteSettingToFile("remotePlaylist","",$pluginName);	
-			}
-		}else {//remote token has not been saved
-			$syncResultDiv= "color: #ff0000; display:block; background-color: black;";
-			$syncResultMessage= "You must enter your remote token first!";
-			WriteSettingToFile("remotePlaylist","",$pluginName);
-		}
-	}else{
-		$syncResultDiv= "color: #ff0000; display:block; background-color: black;";
-		$syncResultMessage= "You didn't select a Playlist";
-		WriteSettingToFile("remotePlaylist","",$pluginName);	
-	}
+$playlists = "";
+if (isset($_POST['updateRemotePlaylist'])) {
+  $remotePlaylist = trim($_POST['remotePlaylist']);
+  if (strlen($remotePlaylist)>=2){
+    if(strlen($remoteToken)>1) {
+      $playlists = array();
+      $remotePlaylistEncoded = rawurlencode($remotePlaylist);
+      $url = "http://127.0.0.1/api/playlist/${remotePlaylistEncoded}";
+      $options = array(
+        'http' => array(
+          'method'  => 'GET'
+          )
+      );
+      $context = stream_context_create( $options );
+      $result = file_get_contents( $url, false, $context );
+      $response = json_decode( $result, true );
+      $mainPlaylist = $response['mainPlaylist'];
+      $index = 1;
+      foreach($mainPlaylist as $item) {
+        if($item['type'] == 'both' || $item['type'] == 'sequence') {
+          $playlist = null;
+          $playlist->playlistName = pathinfo($item['sequenceName'], PATHINFO_FILENAME);
+          $playlist->playlistDuration = $item['duration'];
+          $playlist->playlistIndex = $index;
+          array_push($playlists, $playlist);
+        }else if($item['type'] == 'media') {
+          $playlist = null;
+          $playlist->playlistName = pathinfo($item['mediaName'], PATHINFO_FILENAME);
+          $playlist->playlistDuration = $item['duration'];
+          $playlist->playlistIndex = $index;
+          array_push($playlists, $playlist);
+        }
+        $index++;
+      }
+      $url = $baseUrl . "/remotefalcon/api/syncPlaylists";
+      $data = array(
+        'playlists' => $playlists
+      );
+      $options = array(
+        'http' => array(
+          'method'  => 'POST',
+          'content' => json_encode( $data ),
+          'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
+                      "Accept: application/json\r\n" .
+                      "remotetoken: $remoteToken\r\n"
+          )
+      );
+      $context = stream_context_create( $options );
+      $result = file_get_contents( $url, false, $context );
+      $response = json_decode( $result );
+      if($response) {
+        WriteSettingToFile("remotePlaylist",$remotePlaylist,$pluginName);
+        echo "<script type=\"text/javascript\">$.jGrowl('Remote Playlist Synced!');</script>";
+      }else {
+        echo "<script type=\"text/javascript\">$.jGrowl('Remote Playlist Sync Failed!');</script>";
+      }
+    }else {
+      echo "<script type=\"text/javascript\">$.jGrowl('Remote Token Not Found!');</script>";
+    }
+  }else {
+    echo "<script type=\"text/javascript\">$.jGrowl('No Playlist was Selected!');</script>";
+  }
+}
+
+$remoteFppEnabled = urldecode($pluginSettings['remote_fpp_enabled']);
+$remoteFppEnabled = $remoteFppEnabled == "true" ? true : false;
+$remoteFalconState = "<h4 id=\"remoteFalconRunning\">Remote Falcon is currently running</h4>";
+if($remoteFppEnabled == 0) {
+  $remoteFalconState = "<h4 id=\"remoteFalconStopped\">Remote Falcon is currently stopped</h4>";
+}
+
+if (isset($_POST['updateRemoteToken'])) { 
+  $remoteToken = trim($_POST['remoteToken']);
+  WriteSettingToFile("remoteToken",$remoteToken,$pluginName);
+  echo "<script type=\"text/javascript\">$.jGrowl('Remote Token Updated');</script>";
+}
+
+if (isset($_POST['updateRequestFetchTime'])) { 
+  $requestFetchTime = trim($_POST['requestFetchTime']);
+  WriteSettingToFile("requestFetchTime",$requestFetchTime,$pluginName);
+  echo "<script type=\"text/javascript\">$.jGrowl('Request Fetch Time Updated');</script>";
+}
+
+$interruptSchedule = urldecode($pluginSettings['interrupt_schedule_enabled']);
+$interruptSchedule = $interruptSchedule == "true" ? true : false;
+
+if($interruptSchedule == 1) {
+  $interruptYes = "btn-primary";
+  $interruptNo = "btn-secondary";
+}else {
+  $interruptYes = "btn-secondary";
+  $interruptNo = "btn-primary";
+}
+if (isset($_POST['interruptScheduleYes'])) {
+  $interruptYes = "btn-primary";
+  $interruptNo = "btn-secondary";
+  WriteSettingToFile("interrupt_schedule_enabled",urlencode("true"),$pluginName);
+  echo "<script type=\"text/javascript\">$.jGrowl('Interrupt Schedule On');</script>";
+}
+if (isset($_POST['interruptScheduleNo'])) {
+  $interruptYes = "btn-secondary";
+  $interruptNo = "btn-primary";
+  WriteSettingToFile("interrupt_schedule_enabled",urlencode("false"),$pluginName);
+  echo "<script type=\"text/javascript\">$.jGrowl('Interrupt Schedule Off');</script>";
+}
+
+if (isset($_POST['restartRemoteFalcon'])) {
+  $remoteFalconState = "<h4 id=\"remoteFalconRunning\">Remote Falcon is currently running</h4>";
+  WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
+  WriteSettingToFile("remote_fpp_restarting",urlencode("true"),$pluginName);
+}
+if (isset($_POST['stopRemoteFalcon'])) {
+  $remoteFalconState = "<h4 id=\"remoteFalconStopped\">Remote Falcon is currently stopped</h4>";
+  WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
 }
 
 ?>
@@ -214,92 +194,298 @@ if (isset($_POST['saveRemotePlaylist'])) {
 <!DOCTYPE html>
 <html>
 <head>
-
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1"
+    crossorigin="anonymous">
+  <style>
+    a {
+      color: #D65A31;
+    }
+    .plugin-body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      color: rgb(238, 238, 238);
+      background-color: rgb(34, 40, 49);
+      font-size: 1rem;
+      font-weight: 400;
+      line-height: 1.5;
+      padding-bottom: 2em;
+    }
+    .card {
+      background-color: rgb(59, 69, 84);
+      border-radius: 0.5em;
+      margin: 1em 1em 1em 1em;
+      padding: 1em 1em 1em 1em;
+    }
+    .card-subtitle {
+      font-size: .9rem;
+    }
+    .setting-item {
+      padding-bottom: 2em;
+    }
+    .input-group {
+      padding-top: .5em;
+    }
+    .btn-primary {
+      background-color: #D65A31;
+      border-color: #D65A31;
+    }
+    .btn-primary:hover {
+      background-color: #D65A31;
+      border-color: #D65A31;
+    }
+    .btn-primary:focus {
+      background-color: #D65A31;
+      border-color: #D65A31;
+    }
+    .btn-danger {
+      background-color: #A72525;
+      border-color: #A72525;
+    }
+    .btn-danger:hover {
+      background-color: #A72525;
+      border-color: #A72525;
+    }
+    .btn-danger:focus {
+      background-color: #A72525;
+      border-color: #A72525;
+    }
+    .hvr-underline-from-center {
+      display: inline-block;
+      vertical-align: middle;
+      -webkit-transform: perspective(1px) translateZ(0);
+      transform: perspective(1px) translateZ(0);
+      box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+      position: relative;
+      overflow: hidden;
+    }
+    .hvr-underline-from-center:before {
+      content: "";
+      position: absolute;
+      z-index: -1;
+      left: 51%;
+      right: 51%;
+      bottom: 0;
+      background: #FFF;
+      height: 4px;
+      -webkit-transition-property: left, right;
+      transition-property: left, right;
+      -webkit-transition-duration: 0.3s;
+      transition-duration: 0.3s;
+      -webkit-transition-timing-function: ease-out;
+      transition-timing-function: ease-out;
+    }
+    .hvr-underline-from-center:hover:before, .hvr-underline-from-center:focus:before, .hvr-underline-from-center:active:before {
+      left: 0;
+      right: 0;
+    }
+		#remoteFalconRunning {
+			color: #60F779;
+		}
+		#remoteFalconStopped {
+			color: #A72525;
+		}
+		#update {
+      padding-bottom: 1em;
+      font-weight: bold;
+			color: #A72525;
+		}
+    #env {
+      color: #A72525;
+    }
+    #warning {
+      font-weight: bold;
+      color: #A72525;
+    }
+		#restartNotice {
+			font-weight: bold;
+			color: #D65A31;
+		}
+  </style>
 </head>
 <body>
-<div class="pluginBody" style="margin-left: 1em;">
-	<div class="title">
-		<h1>Remote Falcon Plugin v<? echo $pluginVersion; ?></h1>
-		<? echo $baseUrl == "https://remotefalcon.me" ? "TEST" : "" ?>
-		<h4></h4>
-	</div>
-	<div id="showUpdate" style=" <? echo "$showUpdateDiv"; ?>">
-		<h3 style="color: #a72525;">A new update is available for the Remote Falcon Plugin!</h3>
-		<h3 style="color: #a72525;">Go to the Plugin Manager to update</h3>
-	</div>
-
-	<h3>Remote Falcon log is located in the Logs tab under File Manager.</h3>
-
-	<h3 style="color: #D65A31;">Step 1:</h3>
-	<h5>Place your Remote Token (found in your Remote Falcon Control Panel) in the box below and press Enter.</h5>
-	<h4 style="color: #ff0000"><? echo $validTokenMessage ?></h4>
-	<div>
-<?
-PrintSettingTextSaved("remoteToken", $restart = 1, $reboot = 0, $maxlength = 25, $size = 25, $pluginName = $pluginName);
-?>
-	</div>	
-		<h3 style="color: #D65A31;">Step 2:</h3>
-		<h5>Pick which playlist you want to sync with Remote Falcon and click "Sync Playlist". The playlist you sync with RF should be 
-		its own playlist that is not used in any schedules.
-		<br />
-		Any changes made to the selected playlist will require it to be resynched. 
-		If at any time you want to change the synched playlist, simply select the one you want and click "Sync Playlist".
-		<br />
-		<div id="remotePlaylistDiv" style= "<? echo "$remotePlaylistStyle" ?>" >
-			<h2>Current Synched Playlist-    <strong> <? echo "$remotePlaylist "; ?></strong>
-			</h2>
-		</div>
-	<div>
-		<form method="post">
-<?
-PrintSettingSelect("remotePlaylist", "remotePlaylist", $restart = 1, $reboot = 0, "No playlists are saved", $playlistDropdown, $pluginName = $pluginName, $callbackName = "", $changedFunction = "", $sData = Array());
-?>
-			<input id="saveRemotePlaylistButton" class="button" name="saveRemotePlaylist" type="submit" value="Sync Playlist"/>
-		</form>
-		<div id="syncResult" style="<? echo "$syncResultDiv" ?>">
-			<div>
-				<h4><? echo "$syncResultMessage"; ?></h4>
+  <div class="container plugin-body">
+    <div class="container" style="padding-top: 2em;">
+      <div class="justify-content-md-center row" style="padding-bottom: 1em;">
+        <div class="col-md-auto">
+          <h1>Remote Falcon Plugin v<? echo $pluginVersion; ?></h1>
+        </div>
+      </div>
+      <div class="justify-content-md-center row" style="padding-bottom: 1em;">
+        <div class="col-md-auto">
+          <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=FFKWA2CFP6JC6&currency_code=USD&source=url" target="_blank" rel="noopener noreferrer">
+            <img style="margin-left: 1em;" alt="RF_Donate" src="https://remotefalcon.com/support-button-v2.png">
+          </a>
+        </div>
+      </div>
+			<div class="justify-content-md-center row" style="padding-bottom: 1em;">
+				<div class="col-md-auto">
+          <? echo $remoteFalconState; ?>
+				</div>
 			</div>
-		</div>
-	</div>
-		<h3 style="color: #D65A31;">Step 3:</h3>
-		<h5>Adjust the toggle below to turn Remote FPP on or off.
-		<br />
-		This setting is what allows FPP to retrieve viewer requests.
-		<br />
-		Any time this toggle is modified you must Restart FPP.</h5>
-		<div>
-			<strong>Enable Remote Falcon</strong> 
-<?			
-PrintSettingCheckbox("Remote Falcon", "remote_fpp_enabled", $restart = 1, $reboot = 0, "true", "false", $pluginName = $pluginName, $callbackName = "", $defaultValue = 0, $desc = "", $sData = Array());
-?>
-		</div>
-		<h3 style="color: #D65A31;">Step 4:</h3>
-		<h5>Adjust the toggle below to choose if you want the scheduled playlist to be interrupted when a request is received.
-		<br />
-		Default is on, meaning the scheduled playlist will be interrupted with a new request
-		<br />
-		Any time this toggle is modified you must Restart FPP.</h5>
-		<div>
-			<strong>Interrupt Schedule</strong> 
-<?
-PrintSettingCheckbox("Interrupt Schedule", "interrupt_schedule_enabled", $restart = 1, $reboot = 0, "true", "false", $pluginName = $pluginName, $callbackName = "", $defaultValue = 0, $desc = "", $sData = Array());
-?>
-		</div>
-		<h3 style="#D65A31;">Step 5:</h3>
-		<h5>Restart FPP</h5>
-		<h3 style="color: #D65A31;">Step 6:</h3>
-		<h5>Profit!</h5>
-		<h5>While Remote Falcon is 100% free for users, there are still associated costs with owning and maintaining a server and 
-		database. If you would like to help support Remote Falcon you can donate using the button below.</h5>
-		<h5>Donations will <strong>never</strong> be required but will <strong>always</strong> be appreciated.</h5>
-		<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=FFKWA2CFP6JC6&currency_code=USD&source=url" target="_blank" rel="noopener noreferrer"> <img style="margin-left: 1em;" alt="RF_Donate" src="https://remotefalcon.com/support-button.png"></a>
+      <div style=<? echo "$showUpdateDiv"; ?>>
+        <div id="update" class="justify-content-md-center row">
+          <div class="col-md-auto">
+            <h4>An update is available!</h4>
+          </div>
+        </div>
+      </div>
+      <div class="justify-content-md-center row">
+        <div class="col-md-auto">
+          <h4 id="env"><? echo $baseUrl == "https://remotefalcon.me" ? "TEST" : "" ?></h4>
+        </div>
+      </div>
+    </div>
+    <div class="container">
+      <div class="card">
+        <div class="card-body">
+          <!-- Remote Token -->
+          <div class="justify-content-md-center row setting-item">
+            <div class="col-md-6">
+							<div class="card-title h5">
+								Remote Token <span id="restartNotice"> *</span>
+							</div>
+							<div class="mb-2 text-muted card-subtitle h6">
+								Your Remote Token can be found on the Remote Falcon Control Panel
+							</div>
+						</div>
+            <div class="col-md-6">
+              <form method="post">
+                <div class="input-group">
+                  <input type="text" class="form-control" name="remoteToken" id="remoteToken" placeholder="Remote Token" value=<? echo "$remoteToken "; ?>>
+                  <span class="input-group-btn">
+                    <button id="updateRemoteToken" name="updateRemoteToken" class="btn mr-md-3 hvr-underline-from-center btn-primary" type="submit">Update</button>
+                  </span>
+                </div>
+              </form>
+            </div>
+          </div>
+          <!-- Remote Playlist -->
+          <div class="justify-content-md-center row setting-item">
+            <div class="col-md-6">
+              <div class="card-title h5">
+                Remote Playlist <span id="restartNotice"> *</span>
+              </div>
+              <div class="mb-2 text-muted card-subtitle h6">
+                This is the playlist that contains all the sequences to be controlled by your viewers
+              </div>
+            </div>
+            <div class="col-md-6">
+              <form method="post">
+                <div class="input-group">
+                  <select class="form-select" id="remotePlaylist" name="remotePlaylist">
+                    <option selected value=""></option>
+                    <? echo "$playlistOptions "; ?>
+                  </select>
+                  <span class="input-group-btn">
+                    <button id="updateRemotePlaylist" name="updateRemotePlaylist" class="btn mr-md-3 hvr-underline-from-center btn-primary" type="submit">Update</button>
+                  </span>
+                </div>
+              </form>
+            </div>
+          </div>
+          <!-- Current Remote Playlist -->
+          <div class="justify-content-md-center row setting-item" style="padding-top: .5em;">
+            <div class="col-md-6">
+              <div class="card-title h5">
+                Current Remote Playlist
+              </div>
+              <div class="mb-2 text-muted card-subtitle h6">
+                This is the current playlist synced with Remote Falcon (click to go to Sequences in your Control Panel)
+              </div>
+            </div>
+            <div class="col-md-6">
+              <h5><a href=<? echo "$rfSequencesUrl"; ?> target="_blank" rel="noopener noreferrer"><? echo "$remotePlaylist"; ?></a></h5>
+            </div>
+          </div>
+          <!-- Request Fetch Time -->
+          <div class="justify-content-md-center row setting-item">
+            <div class="col-md-6">
+							<div class="card-title h5">
+								Request/Vote Fetch Time <span id="restartNotice"> *</span>
+							</div>
+							<div class="mb-2 text-muted card-subtitle h6">
+								This sets when the plugin checks for the next request/vote (default is 10 seconds)
+							</div>
+						</div>
+            <div class="col-md-3">
+              <form method="post">
+                <div class="input-group">
+                  <input type="number" class="form-control" name="requestFetchTime" id="requestFetchTime" value=<? echo "$requestFetchTime "; ?>>
+                  <span class="input-group-btn">
+                    <button id="updateRequestFetchTime" name="updateRequestFetchTime" class="btn mr-md-3 hvr-underline-from-center btn-primary" type="submit">Update</button>
+                  </span>
+                </div>
+              </form>
+            </div>
+            <div class="col-md-3">
+            </div>
+          </div>
+          <!-- Interrupt Schedule -->
+          <div class="justify-content-md-center row setting-item">
+            <div class="col-md-6">
+              <div class="card-title h5">
+                Interrupt Schedule <span id="restartNotice"> *</span>
+              </div>
+              <div class="mb-2 text-muted card-subtitle h6">
+                Determines if a request or vote will interrupt the normal schedule
+              </div>
+            </div>
+            <div class="col-md-6">
+              <form method="post">
+                <button class="btn mr-md-3 hvr-underline-from-center <? echo $interruptYes; ?>" id="interruptScheduleYes" name="interruptScheduleYes" type="submit">
+                  Yes
+                </button>
+                <button class="btn mr-md-3 hvr-underline-from-center <? echo $interruptNo; ?>" id="interruptScheduleNo" name="interruptScheduleNo" type="submit">
+                  No
+                </button>
+              </form>
+            </div>
+          </div>
+          <!-- Restart Remote Falcon -->
+          <div class="justify-content-md-center row setting-item">
+            <div class="col-md-6">
+              <div class="card-title h5">
+                Restart Remote Falcon
+              </div>
+              <div class="mb-2 text-muted card-subtitle h6">
+                This will restart the Remote Falcon plugin
+              </div>
+            </div>
+            <div class="col-md-6">
+              <form method="post">
+                <button class="btn mr-md-3 hvr-underline-from-center btn-danger" id="restartRemoteFalcon" name="restartRemoteFalcon" type="submit">
+                  Restart Remote Falcon
+                </button>
+              </form>
+            </div>
+          </div>
+          <!-- Stop Remote Falcon -->
+          <div class="justify-content-md-center row setting-item">
+            <div class="col-md-6">
+              <div class="card-title h5">
+                Stop Remote Falcon
+              </div>
+              <div class="mb-2 text-muted card-subtitle h6">
+                <span id="warning">WARNING! </span>This will immediately stop the Remote Falcon
+                plugin and no requests/votes will be fetched!
+              </div>
+            </div>
+            <div class="col-md-6">
+            <form method="post">
+                <button class="btn mr-md-3 hvr-underline-from-center btn-danger" id="stopRemoteFalcon" name="stopRemoteFalcon" type="submit">
+                  Stop Remote Falcon
+                </button>
+              </form>
+            </div>
+          </div>
+          <span id="restartNotice">* Requires Remote Falcon Restart</span>
+        </div>
+      </div>
+    </div>
+  </div>
 
-		<p>
-			<? echo $responseTimeMessage ?>
-		</p>
-	
-	
-</div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+
 </body>
 </html>

--- a/remote_falcon.php
+++ b/remote_falcon.php
@@ -304,8 +304,8 @@ if (isset($_POST['stopRemoteFalcon'])) {
   </style>
 </head>
 <body>
-  <div class="container plugin-body">
-    <div class="container" style="padding-top: 2em;">
+  <div class="container-fluid plugin-body">
+    <div class="container-fluid" style="padding-top: 2em;">
       <div class="justify-content-md-center row" style="padding-bottom: 1em;">
         <div class="col-md-auto">
           <h1>Remote Falcon Plugin v<? echo $pluginVersion; ?></h1>
@@ -336,7 +336,7 @@ if (isset($_POST['stopRemoteFalcon'])) {
         </div>
       </div>
     </div>
-    <div class="container">
+    <div class="container-fluid">
       <div class="card">
         <div class="card-body">
           <!-- Remote Token -->

--- a/remote_falcon.php
+++ b/remote_falcon.php
@@ -272,12 +272,20 @@ if (isset($_POST['autoRestartPluginNo'])) {
       font-weight: 400;
       line-height: 1.5;
       padding-bottom: 2em;
+      background-image: url("https://remotefalcon.com/brick-wall-background-with-juke.jpg");
+      background-repeat: no-repeat;
+      background-attachment: fixed;
+      background-position: top center;
+      background-size: autp 100%;
     }
     .card {
-      background-color: rgb(59, 69, 84);
+      background-color: rgba(59, 69, 84, 0.7);
       border-radius: 0.5em;
       margin: 1em 1em 1em 1em;
       padding: 1em 1em 1em 1em;
+    }
+    .card-body {
+      background-color: rgba(59, 69, 84, 0);
     }
     .card-subtitle {
       font-size: .9rem;
@@ -369,33 +377,35 @@ if (isset($_POST['autoRestartPluginNo'])) {
 <body>
   <div class="container-fluid plugin-body">
     <div class="container-fluid" style="padding-top: 2em;">
-      <div class="justify-content-md-center row" style="padding-bottom: 1em;">
-        <div class="col-md-auto">
-          <h1>Remote Falcon Plugin v<? echo $pluginVersion; ?></h1>
-        </div>
-      </div>
-      <div class="justify-content-md-center row" style="padding-bottom: 1em;">
-        <div class="col-md-auto">
-          <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=FFKWA2CFP6JC6&currency_code=USD&source=url" target="_blank" rel="noopener noreferrer">
-            <img style="margin-left: 1em;" alt="RF_Donate" src="https://remotefalcon.com/support-button-v2.png">
-          </a>
-        </div>
-      </div>
-			<div class="justify-content-md-center row" style="padding-bottom: 1em;">
-				<div class="col-md-auto">
-          <? echo $remoteFalconState; ?>
-				</div>
-			</div>
-      <div style=<? echo "$showUpdateDiv"; ?>>
-        <div id="update" class="justify-content-md-center row">
+      <div class="card">
+        <div class="card-body"><div class="justify-content-md-center row" style="padding-bottom: 1em;">
           <div class="col-md-auto">
-            <h4>An update is available!</h4>
+            <h1>Remote Falcon Plugin v<? echo $pluginVersion; ?></h1>
           </div>
         </div>
-      </div>
-      <div class="justify-content-md-center row">
-        <div class="col-md-auto">
-          <h4 id="env"><? echo $baseUrl == "https://remotefalcon.me" ? "TEST" : "" ?></h4>
+        <div class="justify-content-md-center row" style="padding-bottom: 1em;">
+          <div class="col-md-auto">
+            <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=FFKWA2CFP6JC6&currency_code=USD&source=url" target="_blank" rel="noopener noreferrer">
+              <img style="margin-left: 1em;" alt="RF_Donate" src="https://remotefalcon.com/support-button-v2.png">
+            </a>
+          </div>
+        </div>
+        <div class="justify-content-md-center row" style="padding-bottom: 1em;">
+          <div class="col-md-auto">
+            <? echo $remoteFalconState; ?>
+          </div>
+        </div>
+        <div style=<? echo "$showUpdateDiv"; ?>>
+          <div id="update" class="justify-content-md-center row">
+            <div class="col-md-auto">
+              <h4>An update is available!</h4>
+            </div>
+          </div>
+        </div>
+        <div class="justify-content-md-center row">
+          <div class="col-md-auto">
+            <h4 id="env"><? echo $baseUrl == "https://remotefalcon.me" ? "TEST" : "" ?></h4>
+          </div>
         </div>
       </div>
     </div>

--- a/remote_falcon.php
+++ b/remote_falcon.php
@@ -276,7 +276,7 @@ if (isset($_POST['autoRestartPluginNo'])) {
       background-repeat: no-repeat;
       background-attachment: fixed;
       background-position: top center;
-      background-size: autp 100%;
+      background-size: auto 100%;
     }
     .card {
       background-color: rgba(59, 69, 84, 0.7);

--- a/remote_fpp.php
+++ b/remote_fpp.php
@@ -168,7 +168,6 @@ function updateNextScheduledSequence($fppStatus, $currentlyPlaying, $nextSchedul
   $mainPlaylist = $playlistDetails->mainPlaylist;
   $nextScheduled = getNextSequence($mainPlaylist, $currentlyPlaying);
   if($nextScheduled != $nextScheduledInRF && $currentPlaylist != $GLOBALS['remotePlaylist']) {
-    echo ("Updating sequence\n");
     updateNextScheduledSequenceInRf($nextScheduled, $remoteToken);
     logEntry("Updated next scheduled sequence to " . $currentlyPlaying);
     $GLOBALS['nextScheduledInRF'] = $nextScheduled;

--- a/remote_fpp.php
+++ b/remote_fpp.php
@@ -81,6 +81,7 @@ while(true) {
                 logEntry("Queuing winning sequence " . $winningSequence . " at index " . $winningSequenceIndex);
                 insertPlaylistAfterCurrent(rawurlencode($remotePlaylist), $winningSequenceIndex);
                 sleep($requestFetchTime);
+                updateCurrentlyPlaying($winningSequence, $GLOBALS['currentlyPlayingInRF'], $remoteToken);
               }else {
                 logEntry($winningSequence . " was not found in " . $remotePlaylist . " or has invalid index (" . $winningSequenceIndex . ")");
               }
@@ -97,6 +98,7 @@ while(true) {
                 logEntry("Queuing requested sequence " . $nextSequence . " at index " . $nextSequenceIndex);
                 insertPlaylistAfterCurrent(rawurlencode($remotePlaylist), $nextSequenceIndex);
                 sleep($requestFetchTime);
+                updateCurrentlyPlaying($nextSequence, $GLOBALS['currentlyPlayingInRF'], $remoteToken);
               }else {
                 logEntry($nextSequence . " was not found in " . $remotePlaylist . " or has invalid index (" . $nextSequenceIndex . ")");
               }
@@ -116,9 +118,7 @@ while(true) {
             if($winningSequenceIndex != 0 && $winningSequenceIndex != -1) {
               insertPlaylistImmediate(rawurlencode($remotePlaylist), $winningSequenceIndex);
               logEntry("Playing winning sequence " . $winningSequence . " at index " . $winningSequenceIndex);
-              updateWhatsPlaying($winningSequence, $remoteToken);
-              logEntry("Updated current playing sequence to " . $winningSequence);
-              $currentlyPlayingInRF = $winningSequence;
+              updateCurrentlyPlaying($winningSequence, $GLOBALS['currentlyPlayingInRF'], $remoteToken);
               holdForImmediatePlay();
             }else {
               logEntry($winningSequence . " was not found in " . $remotePlaylist . " or has invalid index (" . $winningSequenceIndex . ")");
@@ -134,9 +134,7 @@ while(true) {
             if($nextSequenceIndex != 0 && $nextSequenceIndex != -1) {
               insertPlaylistImmediate(rawurlencode($remotePlaylist), $nextSequenceIndex);
               logEntry("Playing requested sequence " . $nextSequence . " at index " . $nextSequenceIndex);
-              updateWhatsPlaying($nextSequence, $remoteToken);
-              logEntry("Updated current playing sequence to " . $nextSequence);
-              $currentlyPlayingInRF = $nextSequence;
+              updateCurrentlyPlaying($nextSequence, $GLOBALS['currentlyPlayingInRF'], $remoteToken);
               holdForImmediatePlay();
             }else {
               logEntry($nextSequence . " was not found in " . $remotePlaylist . " or has invalid index (" . $nextSequenceIndex . ")");
@@ -269,7 +267,7 @@ function highestVotedSequence($remoteToken) {
 }
 
 function nextPlaylistInQueue($remoteToken) {
-  $url = $GLOBALS['baseUrl'] . "/remotefalcon/api/nextPlaylistInQueue";
+  $url = $GLOBALS['baseUrl'] . "/remotefalcon/api/nextPlaylistInQueue?updateQueue=true";
   $options = array(
     'http' => array(
       'method'  => 'GET',

--- a/restart_remote_falcon.php
+++ b/restart_remote_falcon.php
@@ -1,0 +1,7 @@
+<?php
+include_once "/opt/fpp/www/common.php";
+$pluginName = "remote-falcon";
+
+WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
+WriteSettingToFile("remote_fpp_restarting",urlencode("true"),$pluginName);
+?>

--- a/stop_remote_falcon.php
+++ b/stop_remote_falcon.php
@@ -1,0 +1,6 @@
+<?php
+include_once "/opt/fpp/www/common.php";
+$pluginName = "remote-falcon";
+
+WriteSettingToFile("remote_fpp_enabled",urlencode("false"),$pluginName);
+?>


### PR DESCRIPTION
- Complete redesign of plugin page.
- Ability to change config without having to restart FPP
- No longer requires a schedule to be running. Plugin will run and fetch requests/votes as long as FPP status is not idle.
- Added scripts to toggle the interrupt option.
- Added script to purge queue/reset votes.
- Added scripts to stop and restart the plugin to provide control on when requests/votes are fetched or after config changes.
- Added ability to auto-restart plugin when a config changes.
- When no requests are queued, plugin will send what is playing next on the normal scheduled playlist.