### PR TITLE
Hopefully fix restart flag on install.

### DIFF
--- a/remote_falcon.php
+++ b/remote_falcon.php
@@ -11,7 +11,7 @@ if (file_exists($pluginConfigFile)) {
   $pluginSettings = parse_ini_file($pluginConfigFile);
 }
 
-$pluginVersion = "6.3.2";
+$pluginVersion = "6.3.3";
 
 //set defaults if nothing saved
 if (strlen(urldecode($pluginSettings['remotePlaylist']))<1){

--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -8,6 +8,6 @@ make "SRCDIR=${SRCDIR}"
 
 
 . ${FPPDIR}/scripts/common
-setSetting restartFlag 1
+setSetting rebootFlag 1
 
 #fpp_install

--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
 # Mark to reboot
-sed -i -e "s/^restartFlag .*/restartFlag = 1/" ${FPPHOME}/media/settings
+BASEDIR=$(dirname $0)
+cd $BASEDIR
+cd ..
+make "SRCDIR=${SRCDIR}"
+
+
+. ${FPPDIR}/scripts/common
+setSetting restartFlag 1
 
 #fpp_install


### PR DESCRIPTION
After the plugin installs, the reboot flag is not prompting. Hoping this fixes it and prevents issues that can show up if FPP is not restarted.