### PR TITLE
Change FPP Status Check from Int to Float

### DIFF
--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -69,7 +69,7 @@ async function getPluginConfig() {
     ADDITIONAL_WAIT_TIME = parseInt(data?.additionalWaitTime);
   });
   await FPPGet('/api/plugin/remote-falcon/settings/fppStatusCheckTime', (data) => {
-    FPP_STATUS_CHECK_TIME = parseInt(data?.fppStatusCheckTime);
+    FPP_STATUS_CHECK_TIME = parseFloat(data?.fppStatusCheckTime);
   });
   await FPPGet('/api/plugin/remote-falcon/settings/remotePlaylist', (data) => {
     REMOTE_PLAYLIST = data?.remotePlaylist;

--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -16,7 +16,7 @@ var REMOTE_PLAYLIST = null;
 function setApiUrl() {
   var hostname = $(location).attr('hostname');
   if(hostname === 'localhost') {
-    API_URL = 'http://host.docker.internal:8080/remotefalcon/api'
+    API_URL = 'http://localhost:8080/remotefalcon/api'
   }
 }
 

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -24,10 +24,6 @@ $(document).ready(async () => {
     await syncPlaylistToRF();
   });
 
-  $('#resyncRemotePlaylistButton').click(async () => {
-    await syncPlaylistToRF(true);
-  });
-
   $('#interruptScheduleCheckbox').change(async () => {
     const isChecked = $('#interruptScheduleCheckbox').is(':checked');
     await FPPPost('/api/plugin/remote-falcon/settings/interruptSchedule', isChecked.toString(), async () => {
@@ -92,12 +88,9 @@ async function init() {
   hideLoader();
 }
 
-async function syncPlaylistToRF(isResync) {
+async function syncPlaylistToRF() {
   if(REMOTE_TOKEN) {
     var selectedPlaylist = $('#remotePlaylistSelect').val();
-    if(selectedPlaylist === REMOTE_PLAYLIST && !isResync) {
-      return;
-    }
     await FPPGet('/api/playlist/' + encodeURIComponent(selectedPlaylist), async (data) => {
       var sequences = [];
       if(data?.mainPlaylist) {

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "1.0.2";
+$PLUGIN_VERSION = "1.0.3";
 
 include_once "/opt/fpp/www/common.php";
 include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";
@@ -59,8 +59,8 @@ $requestFetchTime = intVal(urldecode($pluginSettings['requestFetchTime']));
 logEntry("Request Fetch Time: " . $requestFetchTime);
 $additionalWaitTime = intVal(urldecode($pluginSettings['additionalWaitTime']));
 logEntry("Additional Wait Time: " . $additionalWaitTime);
-$fppStatusCheckTime = intVal(urldecode($pluginSettings['fppStatusCheckTime']));
-logEntry("FPP Status Check Time: " . $fppStatusCheckTime);
+$fppStatusCheckTime = floatval(urldecode($pluginSettings['fppStatusCheckTime']));
+logEntry("FPP Status Check Time: " . $fppStatusCheckTime . " (" . $fppStatusCheckTime * 1000000 . " microseconds)");
 
 while(true) {
   $pluginSettings = parse_ini_file($pluginConfigFile);
@@ -87,8 +87,8 @@ while(true) {
     logEntry("Request Fetch Time: " . $requestFetchTime);
     $additionalWaitTime = intVal(urldecode($pluginSettings['additionalWaitTime']));
     logEntry("Additional Wait Time: " . $additionalWaitTime);
-    $fppStatusCheckTime = intVal(urldecode($pluginSettings['fppStatusCheckTime']));
-    logEntry("FPP Status Check Time: " . $fppStatusCheckTime);
+    $fppStatusCheckTime = floatval(urldecode($pluginSettings['fppStatusCheckTime']));
+    logEntry("FPP Status Check Time: " . $fppStatusCheckTime . " (" . $fppStatusCheckTime * 1000000 . " microseconds)");
   }
 
   if($remoteFppEnabled == 1) {
@@ -189,7 +189,7 @@ while(true) {
     }
   }
 
-  sleep($fppStatusCheckTime);
+  usleep($fppStatusCheckTime * 1000000);
 }
 
 function updateCurrentlyPlaying($currentlyPlaying, $currentlyPlayingInRF, $remoteToken) {

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "1.0.1";
+$PLUGIN_VERSION = "1.0.2";
 
 include_once "/opt/fpp/www/common.php";
 include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";

--- a/remote_falcon_ui.html
+++ b/remote_falcon_ui.html
@@ -81,7 +81,6 @@
         <div class="col-md-6">
           <div class="input-group">
             <select class="form-control" id="remotePlaylistSelect" name="remotePlaylistSelect"></select>
-            <button id="resyncRemotePlaylistButton" class="buttons btn-outline-success btn-rounded button-margin" type="button">Resync</button>
           </div>
         </div>
       </div>

--- a/remote_falcon_ui.html
+++ b/remote_falcon_ui.html
@@ -168,12 +168,14 @@
             This determines how often the plugin calls to get the status of FPP. </br>
             It's recommended to leave this at 1, but if you experience issues with </br>
             high CPU usage or FPP freezing, you can set this to a higher value. </br>
-            The value must be between 1 and <span id="requestFetchTime"></span> (your current Request/Vote Fetch Time value).
+            The value must be between 1 and <span id="requestFetchTime"></span> (your current Request/Vote Fetch Time value).</br>
+            Note: If you have Interrupt Schedule on and are having issues with the schedule starting for a second </br>
+            then going to the next request, you can try setting this value to 0.5.
           </div>
         </div>
         <div class="col-md-6">
           <div class="input-group">
-            <input type="number" class="form-control" name="fppStatusCheckTimeInput" id="fppStatusCheckTimeInput">
+            <input type="number" min="0" step="0.1" class="form-control" name="fppStatusCheckTimeInput" id="fppStatusCheckTimeInput">
           </div>
         </div>
       </div>


### PR DESCRIPTION
Changed the FPP status check time to allow floats with a step of 0.1 increments. This is to solve the issue with interrupt schedule quickly going back to the schedule.