### PR TITLE
Remove Check Plugin button and need for trimmed playlist.

### DIFF
--- a/commands/descriptions.json
+++ b/commands/descriptions.json
@@ -46,5 +46,15 @@
     "name": "Remote Falcon - Turn Viewer Control On",
     "script": "viewer_control_on.php",
     "args": []
+  },
+  {
+    "name": "Remote Falcon - Turn Managed PSA Off",
+    "script": "managed_psa_off.php",
+    "args": []
+  },
+  {
+    "name": "Remote Falcon - Turn Managed PSA On",
+    "script": "managed_psa_on.php",
+    "args": []
   }
 ]

--- a/commands/managed_psa_off.php
+++ b/commands/managed_psa_off.php
@@ -1,0 +1,31 @@
+#!/usr/bin/env php
+<?php
+$skipJSsettings=true;
+include_once "/opt/fpp/www/config.php";
+include_once "/opt/fpp/www/common.php";
+$pluginName = "remote-falcon";
+include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";
+$baseUrl = getBaseUrl();
+$pluginConfigFile = $settings['configDirectory'] . "/plugin.remote-falcon";
+$pluginSettings = parse_ini_file($pluginConfigFile);
+
+$remoteToken = urldecode($pluginSettings['remoteToken']);
+
+if(strlen($remoteToken)>1) {
+	$url = $baseUrl . "/updateManagedPsa";
+	$data = array(
+		'managedPsaEnabled' => 'N'
+	);
+	$options = array(
+		'http' => array(
+			'method'  => 'POST',
+			'content' => json_encode( $data ),
+			'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
+									"Accept: application/json\r\n" .
+									"remotetoken: $remoteToken\r\n"
+			)
+	);
+	$context = stream_context_create( $options );
+	$result = file_get_contents( $url, false, $context );
+}
+?>

--- a/commands/managed_psa_on.php
+++ b/commands/managed_psa_on.php
@@ -1,0 +1,31 @@
+#!/usr/bin/env php
+<?php
+$skipJSsettings=true;
+include_once "/opt/fpp/www/config.php";
+include_once "/opt/fpp/www/common.php";
+$pluginName = "remote-falcon";
+include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";
+$baseUrl = getBaseUrl();
+$pluginConfigFile = $settings['configDirectory'] . "/plugin.remote-falcon";
+$pluginSettings = parse_ini_file($pluginConfigFile);
+
+$remoteToken = urldecode($pluginSettings['remoteToken']);
+
+if(strlen($remoteToken)>1) {
+	$url = $baseUrl . "/updateManagedPsa";
+	$data = array(
+		'managedPsaEnabled' => 'Y'
+	);
+	$options = array(
+		'http' => array(
+			'method'  => 'POST',
+			'content' => json_encode( $data ),
+			'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
+									"Accept: application/json\r\n" .
+									"remotetoken: $remoteToken\r\n"
+			)
+	);
+	$context = stream_context_create( $options );
+	$result = file_get_contents( $url, false, $context );
+}
+?>

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -21,7 +21,7 @@ $(document).ready(async () => {
   });
 
   $('#syncRemotePlaylistButton').click(async () => {
-    await syncPlaylistToRF(true);
+    await syncPlaylistToRF();
   });
 
   $('#interruptScheduleCheckbox').change(async () => {
@@ -85,6 +85,8 @@ async function init() {
   await checkPluginUpdates();
   await getPlaylists();
   
+  await checkPlugin();
+  
   hideLoader();
 }
 
@@ -126,13 +128,10 @@ async function syncPlaylistToRF() {
       }else {
         await RFAPIPost('/syncPlaylists', {playlists: sequences}, async (data, statusText, xhr) => {
           if(xhr?.status === 200) {
-            REMOTE_PLAYLIST_TRIMMED = $('#remotePlaylistSelect').val().replace(/\s/g, '');
             REMOTE_PLAYLIST = $('#remotePlaylistSelect').val();
             await FPPPost('/api/plugin/remote-falcon/settings/remotePlaylist', REMOTE_PLAYLIST, async () => {
-              await FPPPost('/api/plugin/remote-falcon/settings/remotePlaylistTrimmed', REMOTE_PLAYLIST_TRIMMED, async () => {
-                $.jGrowl("Remote Playlist Saved", { themeState: 'success' });
-                await restartListener();
-              });
+              $.jGrowl("Remote Playlist Saved", { themeState: 'success' });
+              await restartListener();
             });
           }
         })

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "1.0.5";
+$PLUGIN_VERSION = "1.0.6";
 
 include_once "/opt/fpp/www/common.php";
 include_once "/home/fpp/media/plugins/remote-falcon/baseurl.php";

--- a/remote_falcon_ui.html
+++ b/remote_falcon_ui.html
@@ -64,7 +64,7 @@
         </div>
         <div class="col-md-6">
           <div class="input-group">
-            <input type="text" class="form-control" name="remoteTokenInput" id="remoteTokenInput" placeholder="Remote Token" value="">
+            <input type="password" class="form-control" name="remoteTokenInput" id="remoteTokenInput" placeholder="Remote Token" value="">
           </div>
         </div>
       </div>
@@ -106,13 +106,10 @@
             Check Plugin
           </div>
           <div class="mb-2 text-muted card-subtitle">
-            This will run a check on the plugin configuration and report any issues. Results will display below.
+            This will run a check on the plugin configuration and automatically report any issues.
           </div>
         </div>
         <div class="col-md-6">
-          <div class="input-group">
-            <button id="checkPluginButton" class="buttons btn-outline-success btn-rounded" type="button">Check Plugin</button>
-          </div>
           <div id="checkPluginResults">
             
           </div>


### PR DESCRIPTION
- Removed the Check Plugin button and made it so the plugin is checked after each change and on page load.
- Set the field type for Remote Token to password.
- Remove the REMOTE_PLAYLIST_TRIMMED and fetching the remote playlist directly from the config file (bypassing the issue where the plugin setting API trims config values with spaces).