### PR TITLE
Move heartbeat to backend listener; remove JS heartbeat

### DIFF
--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -153,25 +153,6 @@ function hideLoader() {
   $(".plugin-body").css({ 'display' : 'block'});
 }
 
-function startHeartbeat() {
-  sendHeartbeat();
-  setInterval(async () => {
-    sendHeartbeat();
-  }, 15000);
-}
-
-function sendHeartbeat() {
-  if(REMOTE_FALCON_LISTENER_ENABLED) {
-    $.ajax({
-      url: PLUGINS_API_PATH + '/fppHeartbeat',
-      type: 'POST',
-      contentType: 'application/json',
-      async: true,
-      headers: { 'remotetoken': REMOTE_TOKEN }
-    });
-  }
-}
-
 //AJAX Helper Functions
 async function FPPGet(url, successCallback) {
   await $.ajax({

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -103,7 +103,6 @@ async function init() {
   if(REMOTE_TOKEN) {
     await savePluginVersionAndFPPVersionToRF();
     await checkPlugin();
-    startHeartbeat();
   }
   
   hideLoader();


### PR DESCRIPTION
Move heartbeat to backend listener; remove JS heartbeat
- Add periodic heartbeat POST in listener loop
- Remove UI heartbeat logic and call site
- Keeps system health signal independent of browser tab