### PR TITLE
feat(listener): heartbeat post every 30s for dashboard liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to the Remote Falcon FPP plugin are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project uses date-based versioning (`YYYY.MM.DD.NN`).
+
+## [2026.05.15.01] - 2026-05-15
+
+### Added
+- Heartbeat: the listener now posts to `/fppHeartbeat` every 30s independent
+  of show state, so the Remote Falcon dashboard can render plugin liveness
+  and outage windows. First tick fires immediately on startup so the "alive"
+  signal lands without waiting the full interval.
+
+## [2026.01.02.01] and earlier
+
+See the [commit log](https://github.com/Remote-Falcon/remote-falcon-plugin/commits/master)
+for changes prior to this changelog being kept.

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -93,6 +93,13 @@ $verboseLogging = urldecode($pluginSettings['verboseLogging']);
 logEntry("Verbose Logging: " . $verboseLogging);
 $GLOBALS['verboseLogging'] = ($verboseLogging === "true");
 
+// V17 heartbeat — emit a /fppHeartbeat POST every ~30s independent of
+// show state, so the dashboard can render "plugin online" + gap windows.
+// First tick fires immediately so the user doesn't wait 30s for the
+// first "alive" signal after a restart.
+$lastHeartbeatTs = 0;
+$heartbeatIntervalSeconds = 30;
+
 while(true) {
   $pluginSettings = parse_ini_file($pluginConfigFile);
 
@@ -144,6 +151,11 @@ while(true) {
   }
 
   if($remoteFppEnabled == 1) {
+    $nowTs = time();
+    if (($nowTs - $lastHeartbeatTs) >= $heartbeatIntervalSeconds) {
+      fppHeartbeat($remoteToken);
+      $lastHeartbeatTs = $nowTs;
+    }
     logEntry_verbose("Getting FPP Status");
     $fppStatus = getFppStatus();
     if($fppStatus != null && $fppStatus != false) {
@@ -650,6 +662,28 @@ function logEntry_verbose($data) {
 
   fwrite($logWrite, date('Y-m-d h:i:s A',time()).": ".$data."\n");
   fclose($logWrite);
+}
+
+function fppHeartbeat($remoteToken) {
+  $url = $GLOBALS['pluginsApiPath'] . "/fppHeartbeat";
+  $options = array(
+    'http' => array(
+      'method'  => 'POST',
+      'timeout' => 5,
+      'content' => '{}',
+      'header'  => "Content-Type: application/json; charset=UTF-8\r\n" .
+                   "Accept: application/json\r\n" .
+                   "remotetoken: $remoteToken\r\n",
+      'ignore_errors' => true
+    )
+  );
+  $context = stream_context_create($options);
+  $result = @file_get_contents($url, false, $context);
+  if ($result === FALSE) {
+    logEntry_verbose("WARNING - Heartbeat post failed to: " . $url);
+    return false;
+  }
+  return true;
 }
 
 ?>

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "2026.01.02.01";
+$PLUGIN_VERSION = "2026.05.15.01";
 
 include_once "/opt/fpp/www/common.php";
 $pluginName = basename(dirname(__FILE__));


### PR DESCRIPTION
## Summary
- Sends a `POST /fppHeartbeat` (empty JSON body, `remotetoken` header) every ~30s from the listener loop, independent of show state.
- First tick fires immediately so the "alive" signal lands on the dashboard right after a restart instead of waiting the full interval.
- Backend endpoint already exists on `remote-falcon-plugins-api` (returns 204 today; service call gets wired up on the V17 dashboard branch), and the helper uses `'ignore_errors' => true` so older self-hosted backends without the endpoint silently 404 — no log noise, no retry, no user impact.

## Why
The new dashboard renders plugin liveness + outage windows from `show.lastFppHeartbeat` / `heartbeatGaps`, but no client was sending heartbeats. The existing listener only calls the API while a sequence is playing, so an idle show would always look dead on the dashboard.

## Implementation notes
- Single-file change to `remote_falcon_listener.php`, +34 lines / -0. No new files, no `lib/` split, no dependency on the in-flight `perf/listener-tightening` refactor.
- Reuses the same `stream_context_create` + `file_get_contents` pattern as `updateWhatsPlaying` / `updateNextScheduledSequence` for consistency.
- 30s cadence + 5s timeout matches the V17 spec on the backend (`HEARTBEAT_GAP_THRESHOLD_MINUTES = 5L`).

## Test plan
- [x] `php -l remote_falcon_listener.php` passes
- [x] Manually applied to a stock FPP-RF-Test device pointing at a local plugins-api: `POST /fppHeartbeat` hits the server every 30s with the right headers; `show.lastFppHeartbeat` updates in Mongo
- [x] Verified harmless against current prod plugins-api: endpoint returns 204, no Mongo writes, no client-side log noise
- [ ] One overnight soak on a real FPP before tagging a release