### PR TITLE
fix(plugin): strip only the trailing extension, not at first dot

### DIFF
--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -222,15 +222,25 @@ function updateLoaderStatus(message) {
   $('#loaderStatus').text(message);
 }
 
+// Strip ONLY the trailing extension from a filename, preserving any
+// other dots in the name (version numbers, decimal-style ordering,
+// etc.). Returns the input unchanged when it has no extension or is
+// empty/null. Issue #137 — splitting on the first dot lost everything
+// after it for names like "Carol of the Bells v1.2.fseq".
+function stripFileExtension(filename) {
+  if (!filename) return filename;
+  return filename.replace(/\.[^.]+$/, '');
+}
+
 function getPlaylistReadableName(playlist) {
   if (!playlist) {
     return '';
   }
   if (playlist?.sequenceName) {
-    return playlist.sequenceName.split('.')[0];
+    return stripFileExtension(playlist.sequenceName);
   }
   if (playlist?.mediaName) {
-    return playlist.mediaName.split('.')[0];
+    return stripFileExtension(playlist.mediaName);
   }
   if (playlist?.note) {
     return playlist.note;
@@ -346,7 +356,7 @@ async function syncPlaylistToRF() {
             const mediaData = await fetchFppData('/api/media/' + encodeURIComponent(playlist?.mediaName) + "/meta");
             const mediaAlbumUrl = parseAlbumArtUrl(mediaData?.format?.tags?.comment);
             sequences.push({
-              playlistName: playlist?.sequenceName?.split('.')[0],
+              playlistName: stripFileExtension(playlist?.sequenceName),
               playlistDuration: playlist?.duration,
               playlistIndex: playlistIndex,
               playlistType: 'SEQUENCE',
@@ -356,7 +366,7 @@ async function syncPlaylistToRF() {
             });
           } else {
             sequences.push({
-              playlistName: playlist?.sequenceName?.split('.')[0],
+              playlistName: stripFileExtension(playlist?.sequenceName),
               playlistDuration: playlist?.duration,
               playlistIndex: playlistIndex,
               playlistType: 'SEQUENCE',
@@ -364,14 +374,14 @@ async function syncPlaylistToRF() {
           }
         }else if(playlist?.type === 'sequence') {
           sequences.push({
-            playlistName: playlist?.sequenceName?.split('.')[0],
+            playlistName: stripFileExtension(playlist?.sequenceName),
             playlistDuration: playlist?.duration,
             playlistIndex: playlistIndex,
             playlistType: 'SEQUENCE',
           });
         }else if(playlist?.type === 'media') {
           sequences.push({
-            playlistName: playlist?.mediaName?.split('.')[0],
+            playlistName: stripFileExtension(playlist?.mediaName),
             playlistDuration: 0,
             playlistIndex: playlistIndex,
             playlistType: 'MEDIA',


### PR DESCRIPTION
## Summary

Fixes filename truncation during plugin sync. The sync derived sequence display names with `.split('.')[0]`, which truncates at the **first** dot rather than the extension. Filenames containing periods (version numbers, decimal ordering) silently lost everything after the first period when they synced to Remote Falcon.

Before this fix:

| Filename | Synced as | Expected |
|---|---|---|
| `Carol of the Bells v1.2.fseq` | `Carol of the Bells v1` | `Carol of the Bells v1.2` |
| `Track.no.3.fseq` | `Track` | `Track.no.3` |
| `Wizards in Winter 2024.fseq` | `Wizards in Winter 2024` ✓ | `Wizards in Winter 2024` |

Plain filenames (one dot, the extension) worked. Anything with a period inside the filename was corrupted on every sync.

## What changed

Adds a `stripFileExtension(filename)` helper using a tail-anchored regex (`/\.[^.]+$/`). Applies it to **all 6 sites** that previously called `.split('.')[0]`:

- `getPlaylistReadableName` — 2 sites used for the loader status text during sync (these weren't called out in the original issue but are the same bug class)
- `syncPlaylistToRF` — 4 sites across the four playlist-type branches (`both` w/ metadata, `both` w/o metadata, `sequence`, `media`)

Issue #137's "Locations" list only included the 4 in `syncPlaylistToRF`. The 2 in `getPlaylistReadableName` are included here so the "Syncing X..." status messages match the actual synced name.

## Edge cases handled

- `"file.fseq"` → `"file"` (normal extension stripping)
- `"Carol of the Bells v1.2.fseq"` → `"Carol of the Bells v1.2"` (multi-dot preserved)
- `"Track.no.3.fseq"` → `"Track.no.3"` (multi-dot preserved)
- `"noextension"` → `"noextension"` (regex no-op)
- `null` / `undefined` / `""` → returned unchanged (guard preserves prior optional-chaining behavior)

## Test plan

- [ ] Manual: in FPP, create a playlist containing a sequence file with a period in its name (e.g. rename a test sequence to `Test v1.2.fseq`)
- [ ] Trigger a sync from the plugin UI ("Sync Playlist to Remote Falcon")
- [ ] Confirm the sequence appears in the control panel's Sequences tab with the full name (`Test v1.2`, not `Test v1`)
- [ ] Confirm the loader status during sync also shows the full readable name
- [ ] Re-sync a playlist that contains plain-name sequences (no dots) — confirm no regression

## Not added

- **JS tests** — this repo is vanilla JS on FPP with no JS test infrastructure (no `package.json`, no Vitest config). Standing up Vitest for a 16-line behavior fix is out of scope; happy to revisit if the user wants to formalize the JS testing story across the plugin.

## Closes

- Closes Remote-Falcon/remote-falcon-issue-tracker#137
- Supersedes Remote-Falcon/remote-falcon-issue-tracker#81