### PR TITLE
fix: scan past pause entries in getNextSequence + release 2026.06.06.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the Remote Falcon FPP plugin are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project uses date-based versioning (`YYYY.MM.DD.NN`).
 
+## [2026.06.06.01] - 2026-06-06
+
+### Fixed
+- `getNextSequence` now scans forward past pause (and other non-sequence)
+  entries, wrapping at the end of the playlist, instead of giving up when the
+  immediately-following entry has no `sequenceName`. This keeps the dashboard's
+  `NEXT_PLAYLIST` populated when a pause sits between sequences.
+
 ## [2026.05.15.01] - 2026-05-15
 
 ### Added

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "2026.05.15.01";
+$PLUGIN_VERSION = "2026.06.06.01";
 
 include_once "/opt/fpp/www/common.php";
 $pluginName = basename(dirname(__FILE__));

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -369,19 +369,22 @@ function clearNextScheduledSequence($remoteToken) {
 }
 
 function getNextSequence($mainPlaylist, $currentlyPlaying) {
-  $nextScheduled = "";
-  for ($i = 0; $i < count($mainPlaylist); $i++) {
+  $n = count($mainPlaylist);
+  for ($i = 0; $i < $n; $i++) {
     if(isset($mainPlaylist[$i]->sequenceName) && pathinfo($mainPlaylist[$i]->sequenceName, PATHINFO_FILENAME) == $currentlyPlaying) {
-      if($i+1 == count($mainPlaylist)) {
-        $nextScheduled = $mainPlaylist[0]->sequenceName;
-      }else {
-        if(isset($mainPlaylist[$i+1]->sequenceName)) {
-          $nextScheduled = $mainPlaylist[$i+1]->sequenceName;
+      // Scan forward through entries with no sequenceName (pauses, etc.),
+      // wrapping at end of playlist. Return the first sequenceName found.
+      for ($step = 1; $step <= $n; $step++) {
+        $j = ($i + $step) % $n;
+        if(isset($mainPlaylist[$j]->sequenceName)) {
+          return pathinfo($mainPlaylist[$j]->sequenceName, PATHINFO_FILENAME);
         }
       }
+      // No sequence-bearing entry anywhere in the playlist (unlikely in practice)
+      return "";
     }
   }
-  return pathinfo($nextScheduled, PATHINFO_FILENAME);
+  return "";
 }
 
 function remotePreferences($remoteToken) {


### PR DESCRIPTION
## Summary

Two changes, releasing as **2026.06.06.01**:

1. **Fix `getNextSequence` pause handling** — the function now scans forward past pause (and other non-`sequenceName`) entries, wrapping at the end of the playlist, instead of giving up when the immediately-following entry has no `sequenceName`. This keeps the dashboard's `NEXT_PLAYLIST` populated when a pause sits between sequences.

2. **Release bump** — `$PLUGIN_VERSION` 2026.05.15.01 → 2026.06.06.01 so `/pluginVersion` reports the upgrade (and the dashboard's `versionChanges` history records it), plus a matching `CHANGELOG.md` entry.

## Why

Previously, if the entry after the currently-playing sequence was a pause, `getNextSequence` returned an empty string and the dashboard showed no upcoming sequence. The new forward-scan resolves the next *actual* sequence.

## Notes

- Affects the `master` branch (FPP 5.0+). The `master-4` branch (FPP 2.0–4.9.9) predates this function — no backport needed.
- `php -l` passes clean.