### PR TITLE
fix: route browser->RF calls server-side for self-hosted (#157) + cut beta.2

### DIFF
--- a/BETA-TESTING.md
+++ b/BETA-TESTING.md
@@ -1,9 +1,9 @@
 # Remote Falcon Plugin — Beta Testing
 
-Thanks for helping test the next release. The current beta is tagged **`v2026.05.10-beta.1`** — a performance + reliability pass on the FPP listener that has been validated against five FPP major versions in Docker, an 8-hour soak on a real Pi 3, and the full hardware integration suite.
+Thanks for helping test the next release. The current beta is tagged **`v2026.05.10-beta.2`** — a performance + reliability pass on the FPP listener (validated against five FPP major versions in Docker, an 8-hour soak on a real Pi 3, and the full hardware integration suite), plus a fix that lets the **Test Connectivity** button and version reporting work against self-hosted Remote Falcon instances.
 
 Release page (with notes and stable download URL):
-https://github.com/Remote-Falcon/remote-falcon-plugin/releases/tag/v2026.05.10-beta.1
+https://github.com/Remote-Falcon/remote-falcon-plugin/releases/tag/v2026.05.10-beta.2
 
 **Why a tag and not a branch:** the tag is immutable — once `v2026.05.10-beta.1` is published, that exact code is what you get every time, forever. If we cut a follow-up beta you'll get `v2026.05.10-beta.2` (or similar) and decide whether to install it deliberately. No surprise updates from a moving branch.
 
@@ -30,6 +30,7 @@ You should not need to change anything in your existing config. Behavior changes
 - **Settings file is no longer re-parsed every tick.** It is reloaded only when its modification time changes.
 - **Restart Listener no longer races itself.** Rapid clicks of the Restart button can no longer spawn multiple listeners.
 - **Logrotate config installed.** Listener log is rotated automatically; you should not see it grow unbounded any more.
+- **Self-hosted connectivity fixed (beta.2).** The **Test Connectivity** button and the plugin-version report now run server-side, so they work against a self-hosted Remote Falcon API URL instead of failing with `ajax_failed`. No effect if you use the default `remotefalcon.com` URL.
 
 None of the above changes the way you configure the plugin. Your existing settings continue to work.
 
@@ -88,7 +89,7 @@ All commands run on the FPP host as `fpp` (over SSH). The `BETA_TAG` variable up
 
 ```bash
 # Which beta you're installing. Change only this line if a newer beta tag exists.
-BETA_TAG=v2026.05.10-beta.1
+BETA_TAG=v2026.05.10-beta.2
 
 # Step A — Belt-and-suspenders backup of your settings.
 # The install path does NOT touch this file, but a backup costs nothing.
@@ -128,7 +129,7 @@ cat /home/fpp/media/plugins/remote-falcon/remote_falcon_listener.pid
 ps -p $(cat /home/fpp/media/plugins/remote-falcon/remote_falcon_listener.pid) \
     -o pid,user,etime,cmd
 
-# 5.3 — Log should show the new startup banner with version 2026.01.02.01
+# 5.3 — Log should show the new startup banner with version 2026.05.10-beta.2
 #       and your settings echoed back.
 tail -20 /home/fpp/media/logs/remote-falcon-listener.log
 

--- a/health_check.php
+++ b/health_check.php
@@ -1,0 +1,50 @@
+<?php
+// Server-side connectivity probe for the "Test Connectivity" UI button.
+//
+// Invoked same-origin via:
+//   plugin.php?plugin=remote-falcon&page=health_check.php&nopage=1
+//
+// The probe runs the /q/health GET from the FPP server itself — the same
+// network path the listener daemon uses — instead of from the browser. A
+// browser-side request is subject to FPP's Apache Content-Security-Policy,
+// whose connect-src allowlist only contains https://remotefalcon.com, so a
+// self-hosted plugins-api URL is blocked and the test reports a false failure
+// even though the listener can reach the API. Running it server-side sidesteps
+// CSP entirely. See remote-falcon-issue-tracker#157.
+//
+// Must be requested with &nopage=1 so FPP's plugin.php emits no HTML/JS before
+// this page (nopage mode loads config.php only, which populates $settings, and
+// skips common.php). We therefore rely on $settings and our own libs, and emit
+// nothing before the JSON body.
+
+require_once __DIR__ . '/lib/listener_http.php';
+require_once __DIR__ . '/commands/_lib.php';
+
+header('Content-Type: application/json');
+
+$cfg = rf_load_settings();
+if ($cfg === null) {
+    echo json_encode(['ok' => false, 'error' => 'settings_unavailable']);
+    exit;
+}
+
+$base = rtrim($cfg['pluginsApiPath'], '/');
+if ($base === '') {
+    echo json_encode(['ok' => false, 'error' => 'no_api_path']);
+    exit;
+}
+
+$start = microtime(true);
+$body = rf_http_request('GET', $base . '/q/health', ['remotetoken' => $cfg['remoteToken']], null, 5);
+$latencyMs = (int) round((microtime(true) - $start) * 1000);
+
+if ($body === null) {
+    echo json_encode(['ok' => false, 'error' => 'unreachable', 'latencyMs' => $latencyMs]);
+    exit;
+}
+
+$data = rf_http_decode_json($body);
+$status = (is_object($data) && isset($data->status)) ? $data->status : null;
+$ok = ($status !== null && strtoupper((string) $status) === 'UP');
+
+echo json_encode(['ok' => $ok, 'status' => $status, 'latencyMs' => $latencyMs]);

--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -43,9 +43,12 @@ async function savePluginVersionAndFPPVersionToRF() {
       pluginVersion: PLUGIN_VERSION,
       fppVersion: data?.version
     }
-    await RFAPIPost('/pluginVersion', request, () => {},
+    // Report the version server-side (via plugin.php) rather than from the
+    // browser, so it isn't blocked by Apache's CSP for self-hosted API URLs.
+    // See issue #157.
+    await FPPPost('/plugin.php?plugin=remote-falcon&page=report_version.php&nopage=1', JSON.stringify(request), () => {},
       (xhr, status, error) => {
-      console.error('RFAPIPost Error:', status, error);
+      console.error('Version report error:', status, error);
       hideLoader();
     });
   });
@@ -270,43 +273,7 @@ async function FPPPost(url, data, successCallback, errorCallback = null) {
   });
 }
 
-async function RFAPIGet(url, successCallback, errorCallback = null) {
-  await $.ajax({
-    url: PLUGINS_API_PATH + url,
-    type: 'GET',
-    async: true,
-    headers: {'remotetoken': REMOTE_TOKEN},
-    success: (data, statusText, xhr) => {
-      successCallback(data, statusText, xhr);
-    },
-    error: (xhr, status, error) => {
-      if (errorCallback) {
-        errorCallback(xhr, status, error);
-      } else {
-        console.error('RFAPIGet Error:', status, error);
-      }
-    }
-  });
-}
-
-async function RFAPIPost(url, data, successCallback, errorCallback = null) {
-  await $.ajax({
-    url: PLUGINS_API_PATH + url,
-    type: 'POST',
-    contentType: 'application/json',
-    dataType: 'json',
-    data: JSON.stringify(data),
-    async: true,
-    headers: { 'remotetoken': REMOTE_TOKEN },
-    success: (data, statusText, xhr) => {
-      successCallback(data, statusText, xhr);
-    },
-    error: (xhr, status, error) => {
-      if (errorCallback) {
-        errorCallback(xhr, status, error);
-      } else {
-        console.error('RFAPIGet Error:', status, error);
-      }
-    }
-  });
-}
+// Browser -> Remote Falcon API calls have been removed: every RF call the UI
+// used to make from the browser (health check, version report, playlist sync)
+// now runs server-side via plugin.php proxies, so none are subject to Apache's
+// CSP for self-hosted API URLs. See issue #157.

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -394,7 +394,10 @@ async function syncPlaylistToRF() {
 
       updateSyncProgress('Syncing with Remote Falcon...', 90, '');
 
-      await RFAPIPost('/syncPlaylists', {playlists: sequences}, async (data, statusText, xhr) => {
+      // Sync server-side (via plugin.php) so the POST isn't blocked by Apache's
+      // CSP for self-hosted API URLs. The browser still builds the full payload
+      // (types + metadata); this is a transparent pass-through. See issue #157.
+      await FPPPost('/plugin.php?plugin=remote-falcon&page=sync_playlists.php&nopage=1', JSON.stringify({playlists: sequences}), async (data, statusText, xhr) => {
         if(xhr?.status === 200) {
           updateSyncProgress('Sync complete', 100);
           REMOTE_PLAYLIST = $('#remotePlaylistSelect').val();
@@ -473,19 +476,18 @@ async function runConnectivityTest(showToast = false) {
   }
 
   try {
-    const start = performance.now();
     let result = null;
-    await RFAPIGet('/q/health', (data, _statusText, xhr) => {
-      const latency = performance.now() - start;
+    // Probe the RF API server-side (via plugin.php) rather than from the
+    // browser, so the test uses the same network path as the listener and is
+    // not blocked by Apache's CSP for self-hosted API URLs. See issue #157.
+    await FPPGet('/plugin.php?plugin=remote-falcon&page=health_check.php&nopage=1', (data) => {
+      const parsed = typeof data === 'string' ? JSON.parse(data) : data;
       result = {
-        ok: xhr?.status === 200 && data?.status && data.status.toUpperCase() === 'UP',
-        status: data?.status,
-        latencyMs: Math.round(latency),
-        error: null
+        ok: parsed?.ok === true,
+        status: parsed?.status,
+        latencyMs: parsed?.latencyMs,
+        error: parsed?.error || null
       };
-    }, (xhr, status, error) => {
-      console.error('RFAPIGet Error:', status, error);
-      result = { ok: false, error: error || status };
     });
 
     if(result?.ok) {

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -1,5 +1,5 @@
 <?php
-$PLUGIN_VERSION = "2026.01.02.01";
+$PLUGIN_VERSION = "2026.05.10-beta.2";
 
 // /opt/fpp/www/common.php is FPP's PHP "common functions" file, authored
 // for the web-UI context: it emits HTML markup (script tags, settings-

--- a/report_version.php
+++ b/report_version.php
@@ -1,0 +1,52 @@
+<?php
+// Server-side proxy for the plugin -> Remote Falcon version report.
+//
+// Invoked same-origin via:
+//   plugin.php?plugin=remote-falcon&page=report_version.php&nopage=1
+//
+// The browser previously POSTed /pluginVersion directly to the RF API. That
+// request is blocked by FPP's Apache Content-Security-Policy for self-hosted
+// (non-remotefalcon.com) API URLs, so a self-hosted dashboard never recorded
+// the plugin/FPP version. Forwarding the POST from the FPP server is the same
+// path the listener uses and is not subject to CSP. See
+// remote-falcon-issue-tracker#157.
+//
+// Must be requested with &nopage=1 (see health_check.php for why). The browser
+// supplies the {pluginVersion, fppVersion} payload it already gathers from the
+// same-origin FPP API; we forward it verbatim with the show's remote token.
+
+require_once __DIR__ . '/lib/listener_http.php';
+require_once __DIR__ . '/commands/_lib.php';
+
+header('Content-Type: application/json');
+
+$cfg = rf_load_settings();
+if ($cfg === null || strlen($cfg['remoteToken']) <= 1) {
+    echo json_encode(['ok' => false, 'error' => 'no_token']);
+    exit;
+}
+
+$base = rtrim($cfg['pluginsApiPath'], '/');
+if ($base === '') {
+    echo json_encode(['ok' => false, 'error' => 'no_api_path']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    $input = [];
+}
+$payload = json_encode([
+    'pluginVersion' => $input['pluginVersion'] ?? '',
+    'fppVersion' => $input['fppVersion'] ?? '',
+]);
+
+$response = rf_http_request(
+    'POST',
+    $base . '/pluginVersion',
+    ['Content-Type' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
+    $payload,
+    10
+);
+
+echo json_encode(['ok' => $response !== null]);

--- a/sync_playlists.php
+++ b/sync_playlists.php
@@ -1,0 +1,62 @@
+<?php
+// Server-side proxy for the "Sync with RF" button.
+//
+// Invoked same-origin via:
+//   plugin.php?plugin=remote-falcon&page=sync_playlists.php&nopage=1
+//
+// Forwards the browser-built {playlists:[...]} payload to
+// <pluginsApiPath>/syncPlaylists from the FPP server, so the POST is not
+// blocked by FPP's Apache Content-Security-Policy for self-hosted
+// (non-remotefalcon.com) API URLs. See remote-falcon-issue-tracker#157.
+//
+// This is a transparent pass-through: the browser remains the source of truth
+// for the payload (playlist types, media title/artist, album art, ordering).
+// The headless "Remote Falcon - Update Remote Playlist" FPP command builds a
+// thinner payload and is intentionally NOT touched here — the two sync paths
+// have drifted and reconciling them is tracked separately.
+//
+// Must be requested with &nopage=1 (see health_check.php for why).
+
+require_once __DIR__ . '/lib/listener_http.php';
+require_once __DIR__ . '/commands/_lib.php';
+
+header('Content-Type: application/json');
+
+$cfg = rf_load_settings();
+if ($cfg === null || strlen($cfg['remoteToken']) <= 1) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'no_token']);
+    exit;
+}
+
+$base = rtrim($cfg['pluginsApiPath'], '/');
+if ($base === '') {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'no_api_path']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input) || !isset($input['playlists']) || !is_array($input['playlists'])) {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'invalid_payload']);
+    exit;
+}
+
+$payload = json_encode(['playlists' => $input['playlists']]);
+
+$response = rf_http_request(
+    'POST',
+    $base . '/syncPlaylists',
+    ['Content-Type' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
+    $payload,
+    30
+);
+
+if ($response === null) {
+    http_response_code(502);
+    echo json_encode(['ok' => false, 'error' => 'sync_failed']);
+    exit;
+}
+
+echo json_encode(['ok' => true]);


### PR DESCRIPTION
## What & why

Fixes **#157** — self-hosters hit `ajax_failed` on **Test Connectivity** because the browser-side health check is blocked by FPP's Apache CSP (`connect-src` only allows `remotefalcon.com`). The same CSP also silently broke two other browser→RF calls: the plugin-version report and the **Sync with RF** button.

All three now run **server-side** via same-origin `plugin.php` proxies (`nopage` mode, clean JSON), over the same network path the listener uses — so they're not subject to CSP and work against any self-hosted API URL:

- `health_check.php` — probes `<pluginsApiPath>/q/health`
- `report_version.php` — forwards the `{pluginVersion, fppVersion}` payload
- `sync_playlists.php` — forwards the browser-built `{playlists:[...]}` payload

The browser still builds the sync payload (types + media metadata) and drives its progress UI; the proxies are transparent pass-throughs. `pluginsApiPath` is trailing-slash normalized (fixes the `//q/health` double slash). The now-unused `RFAPIGet`/`RFAPIPost` browser helpers are removed — there are no browser→RF calls left.

## Beta cut

Bumps `$PLUGIN_VERSION` → `2026.05.10-beta.2` and updates `BETA-TESTING.md`. Tag `v2026.05.10-beta.2` to follow once merged.

## Not in scope

The headless **"Remote Falcon - Update Remote Playlist"** FPP command builds a thinner payload than the button (no `playlistType`, no media metadata) and is intentionally left untouched. Reconciling the two sync paths is tracked in **#158**.

## Testing

PHP `-l` and `node --check` clean. Server-side behavior needs validation on a real self-hosted FPP — that's what beta.2 is for.
