### PR TITLE
fix(plugin): raise client-side sync guard 200 → 500 items

### DIFF
--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -333,8 +333,8 @@ async function syncPlaylistToRF() {
       const playlistItems = data?.mainPlaylist || [];
       const totalCount = playlistItems.length;
 
-      if(PLUGINS_API_PATH.includes("remotefalcon.com") && totalItems > 200) {
-        $.jGrowl("Cannot sync more than 200 items", { themeState: 'danger' });
+      if(PLUGINS_API_PATH.includes("remotefalcon.com") && totalItems > 500) {
+        $.jGrowl("Cannot sync more than 500 items", { themeState: 'danger' });
         return;
       }
 


### PR DESCRIPTION
The SaaS sync path (`PLUGINS_API_PATH.includes("remotefalcon.com")`) rejected playlists with more than 200 items **client-side**, before ever calling plugins-api — so it masked the backend's new 500-sequence limit. Raise the guard (threshold + message) to 500 to match.

Pairs with the plugins-api `sequence.limit` 200 → 500 bump (Remote-Falcon/remote-falcon-platform#76). Release ordering is safe either way: with the backend at 500 and the plugin still at 200, SaaS users just stay capped at 200 (no breakage) until this ships.

Self-host users are unaffected by this guard (it's gated to `remotefalcon.com`); their limit comes from the backend `SEQUENCE_LIMIT` env.

Note: the beta branch `perf/listener-tightening` still carries the old 200 guard — it'll pick this up on its next sync from `master` (or can be cherry-picked if beta testers need 500 sooner).