### PR TITLE
fix(plugin): raise client-side sync guard 200 → 500 items

### DIFF
--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -323,8 +323,8 @@ async function syncPlaylistToRF() {
       const playlistItems = data?.mainPlaylist || [];
       const totalCount = playlistItems.length;
 
-      if(PLUGINS_API_PATH.includes("remotefalcon.com") && totalItems > 200) {
-        $.jGrowl("Cannot sync more than 200 items", { themeState: 'danger' });
+      if(PLUGINS_API_PATH.includes("remotefalcon.com") && totalItems > 500) {
+        $.jGrowl("Cannot sync more than 500 items", { themeState: 'danger' });
         return;
       }
 


### PR DESCRIPTION
Targets the beta branch (`perf/listener-tightening`) so it rides into the next full release.

The SaaS sync path (`PLUGINS_API_PATH.includes("remotefalcon.com")`) rejected playlists with more than 200 items **client-side**, before ever calling plugins-api — masking the backend's new 500-sequence limit (Remote-Falcon/remote-falcon-platform#76). Raise the guard threshold + message to 500 to match.

Self-host users are unaffected (the guard is gated to `remotefalcon.com`); their limit comes from the backend `SEQUENCE_LIMIT` env.