### PR TITLE
fix: build sync payload server-side in one shared builder for UI and command paths (#158)

### DIFF
--- a/commands/update_remote_playlist.php
+++ b/commands/update_remote_playlist.php
@@ -1,75 +1,52 @@
 #!/usr/bin/env php
 <?php
-$skipJSsettings=true;
+// FPP command: "Remote Falcon - Update Remote Playlist"
+//
+// Syncs the given FPP playlist to Remote Falcon via the shared builder
+// (lib/sync_builder.php), so this headless path sends the exact same rich
+// payload as the UI "Sync with RF" button: playlist types, media
+// title/artist/album art (when the Auto Sync Metadata setting is on), and
+// command items. See issue #158 for the drift this replaced.
+//
+// On success it saves the playlist as the synced remotePlaylist and restarts
+// the listener (the listener caches remotePlaylist at startup).
+
+$skipJSsettings = true;
 include_once "/opt/fpp/www/config.php";
 include_once "/opt/fpp/www/common.php";
+
+require_once __DIR__ . '/_lib.php';
+require_once __DIR__ . '/../lib/listener_http.php';
+require_once __DIR__ . '/../lib/sync_builder.php';
+
 $pluginName = "remote-falcon";
-$pluginConfigFile = $settings['configDirectory'] . "/plugin.remote-falcon";
-$pluginSettings = parse_ini_file($pluginConfigFile);
+$remotePlaylist = isset($argv[1]) ? $argv[1] : '';
 
-/**
- * IF USING THIS SCRIPT AND NOT THE COMMAND, JUST CHANGE THE remotePlaylist VARIABLE FROM $argv[1] TO THE PLAYLIST YOU WANT TO SYNC
- */
-$remotePlaylist = $argv[1];
+if ($remotePlaylist === '') {
+    echo "No playlist name given\n";
+    exit(1);
+}
 
-$remoteToken = urldecode($pluginSettings['remoteToken']);
-$pluginsApiPath = urldecode($pluginSettings['pluginsApiPath']);
-$remoteFalconListenerEnabled = urldecode($pluginSettings['remoteFalconListenerEnabled']);
+$cfg = rf_load_settings();
+if ($cfg === null || strlen($cfg['remoteToken']) <= 1) {
+    echo "Remote Token Missing\n";
+    exit(1);
+}
 
-if(strlen($remoteToken)>1) {
-  echo "Updating\n";
-  $playlists = array();
-  $remotePlaylistEncoded = rawurlencode($remotePlaylist);
-  $url = "http://127.0.0.1/api/playlist/" . $remotePlaylistEncoded;
-  $options = array(
-    'http' => array(
-      'method'  => 'GET'
-      )
-  );
-  $context = stream_context_create( $options );
-  $result = file_get_contents( $url, false, $context );
-  $response = json_decode( $result, true );
-  $mainPlaylist = $response['mainPlaylist'];
-  $index = 1;
-  foreach($mainPlaylist as $item) {
-    if($item['type'] == 'both' || $item['type'] == 'sequence') {
-      $playlist = null;
-      $playlist['playlistName'] = pathinfo($item['sequenceName'], PATHINFO_FILENAME);
-      $playlist['playlistDuration'] = $item['duration'];
-      $playlist['playlistIndex'] = $index;
-      $playlists[] = $playlist;
-    }else if($item['type'] == 'media') {
-      $playlist = null;
-      $playlist['playlistName'] = pathinfo($item['mediaName'], PATHINFO_FILENAME);
-      $playlist['playlistDuration'] = $item['duration'];
-      $playlist['playlistIndex'] = $index;
-      $playlists[] = $playlist;
+echo "Updating\n";
+$result = rf_sync_playlist_to_rf($remotePlaylist, $cfg);
+
+if ($result['ok']) {
+    WriteSettingToFile("remotePlaylist", urlencode($remotePlaylist), $pluginName);
+    $remoteFalconListenerEnabled = isset($cfg['raw']['remoteFalconListenerEnabled'])
+        ? urldecode($cfg['raw']['remoteFalconListenerEnabled']) : '';
+    if ($remoteFalconListenerEnabled == "true") {
+        WriteSettingToFile("remoteFalconListenerEnabled", urlencode("false"), $pluginName);
+        WriteSettingToFile("remoteFalconListenerRestarting", urlencode("true"), $pluginName);
     }
-    $index++;
-  }
-  $url = $pluginsApiPath . "/syncPlaylists";
-  $data = array(
-    'playlists' => $playlists
-  );
-  $options = array(
-    'http' => array(
-      'method'  => 'POST',
-      'content' => json_encode( $data ),
-      'header'=>  "Content-Type: application/json; charset=UTF-8\r\n" .
-                  "Accept: application/json\r\n" .
-                  "remotetoken: $remoteToken\r\n"
-      )
-  );
-  $context = stream_context_create( $options );
-  $result = file_get_contents( $url, false, $context );
-  $response = json_decode( $result );
-  if($response) {
-    WriteSettingToFile("remotePlaylist",urlencode($remotePlaylist),$pluginName);
-    if($remoteFalconListenerEnabled == "true") {
-      WriteSettingToFile("remoteFalconListenerEnabled",urlencode("false"),$pluginName);
-      WriteSettingToFile("remoteFalconListenerRestarting",urlencode("true"),$pluginName);
-    }
-  }
-  echo "Done!";
+    echo "Done! Synced " . $result['count'] . " items.\n";
+} else {
+    echo "Sync failed: " . $result['error'] . "\n";
+    exit(1);
 }
 ?>

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -222,49 +222,12 @@ function updateLoaderStatus(message) {
   $('#loaderStatus').text(message);
 }
 
-// Strip ONLY the trailing extension from a filename, preserving any
-// other dots in the name (version numbers, decimal-style ordering,
-// etc.). Returns the input unchanged when it has no extension or is
-// empty/null. Issue #137 — splitting on the first dot lost everything
-// after it for names like "Carol of the Bells v1.2.fseq".
-function stripFileExtension(filename) {
-  if (!filename) return filename;
-  return filename.replace(/\.[^.]+$/, '');
-}
-
-function getPlaylistReadableName(playlist) {
-  if (!playlist) {
-    return '';
-  }
-  if (playlist?.sequenceName) {
-    return stripFileExtension(playlist.sequenceName);
-  }
-  if (playlist?.mediaName) {
-    return stripFileExtension(playlist.mediaName);
-  }
-  if (playlist?.note) {
-    return playlist.note;
-  }
-  return '';
-}
-
-function parseAlbumArtUrl(commentTag) {
-  if (!commentTag || typeof commentTag !== 'string') {
-    return '';
-  }
-  let candidate = commentTag.trim();
-  if (candidate.endsWith(',')) {
-    candidate = candidate.slice(0, -1).trim();
-  }
-  if (candidate.startsWith('"') && candidate.endsWith('"')) {
-    candidate = candidate.slice(1, -1).trim();
-  }
-  return isImageUrl(candidate) ? candidate : '';
-}
-
-function isImageUrl(url) {
-  return /^https?:\/\/\S+\.(png|jpe?g|gif|webp|bmp|svg)(\?\S*)?$/i.test(url);
-}
+// NOTE: the payload-building helpers that used to live here
+// (stripFileExtension, getPlaylistReadableName, parseAlbumArtUrl,
+// isImageUrl) moved server-side to lib/sync_builder.php in #158 — the
+// browser no longer builds the sync payload. stripFileExtension's
+// dot-preserving behavior (#137) is covered by rf_strip_file_extension
+// and its tests.
 
 function ensureSyncOverlay() {
   if ($('#rfSyncProgressOverlay').length) {
@@ -304,121 +267,43 @@ function hideSyncProgress() {
   $('#rfSyncProgressOverlay').fadeOut(150);
 }
 
-async function fetchFppData(url) {
-  let result = null;
-  try {
-    await FPPGet(url, (data) => {
-      result = data;
-    });
-  } catch (error) {
-    console.error('FPPGet failed for', url, error);
-  }
-  return result;
-}
-
 async function syncPlaylistToRF() {
   if(REMOTE_TOKEN) {
-    var selectedPlaylist = $('#remotePlaylistSelect').val();
+    const selectedPlaylist = $('#remotePlaylistSelect').val();
     const shouldSyncMetadata = $('#autoSyncMetadataCheckbox').is(':checked');
-    updateSyncProgress('Loading playlist...', 10);
+    updateSyncProgress('Syncing with Remote Falcon...', 40);
 
     try {
-      const data = await fetchFppData('/api/playlist/' + encodeURIComponent(selectedPlaylist));
-      if(!data) {
-        $.jGrowl("Unable to load playlist", { themeState: 'danger' });
-        return;
-      }
-
-      var totalItems = data?.playlistInfo?.total_items;
-      const playlistItems = data?.mainPlaylist || [];
-      const totalCount = playlistItems.length;
-
-      if(PLUGINS_API_PATH.includes("remotefalcon.com") && totalItems > 500) {
-        $.jGrowl("Cannot sync more than 500 items", { themeState: 'danger' });
-        return;
-      }
-
-      var sequences = [];
-      var playlistIndex = 1;
-      var processed = 0;
-
-      for (const playlist of playlistItems) {
-        processed++;
-        const readableName = getPlaylistReadableName(playlist);
-        updateSyncProgress(
-          `Gathering metadata ${processed}/${totalCount}`,
-          totalCount ? (Math.round((processed / totalCount) * 70) + 10) : 30,
-          readableName
-        );
-
-        if(playlist?.type == 'both') {
-          if (shouldSyncMetadata) {
-            const mediaData = await fetchFppData('/api/media/' + encodeURIComponent(playlist?.mediaName) + "/meta");
-            const mediaAlbumUrl = parseAlbumArtUrl(mediaData?.format?.tags?.comment);
-            sequences.push({
-              playlistName: stripFileExtension(playlist?.sequenceName),
-              playlistDuration: playlist?.duration,
-              playlistIndex: playlistIndex,
-              playlistType: 'SEQUENCE',
-              mediaTitle: mediaData?.format?.tags?.title ? mediaData?.format?.tags?.title : '',
-              mediaArtist: mediaData?.format?.tags?.artist ? mediaData?.format?.tags?.artist : '',
-              mediaAlbumUrl: mediaAlbumUrl,
-            });
-          } else {
-            sequences.push({
-              playlistName: stripFileExtension(playlist?.sequenceName),
-              playlistDuration: playlist?.duration,
-              playlistIndex: playlistIndex,
-              playlistType: 'SEQUENCE',
-            });
-          }
-        }else if(playlist?.type === 'sequence') {
-          sequences.push({
-            playlistName: stripFileExtension(playlist?.sequenceName),
-            playlistDuration: playlist?.duration,
-            playlistIndex: playlistIndex,
-            playlistType: 'SEQUENCE',
-          });
-        }else if(playlist?.type === 'media') {
-          sequences.push({
-            playlistName: stripFileExtension(playlist?.mediaName),
-            playlistDuration: 0,
-            playlistIndex: playlistIndex,
-            playlistType: 'MEDIA',
-          });
-        }else if(playlist?.type === 'command' && playlist?.note != null) {
-          sequences.push({
-            playlistName: playlist?.note,
-            playlistDuration: 0,
-            playlistIndex: playlistIndex,
-            playlistType: 'COMMAND',
-          });
-        }
-        playlistIndex++;
-      }
-
-      if(sequences.length === 0) {
-        $.jGrowl("Playlist is Empty", { themeState: 'danger' });
-        return;
-      }
-
-      updateSyncProgress('Syncing with Remote Falcon...', 90, '');
-
-      // Sync server-side (via plugin.php) so the POST isn't blocked by Apache's
-      // CSP for self-hosted API URLs. The browser still builds the full payload
-      // (types + metadata); this is a transparent pass-through. See issue #157.
-      await FPPPost('/plugin.php?plugin=remote-falcon&page=sync_playlists.php&nopage=1', JSON.stringify({playlists: sequences}), async (data, statusText, xhr) => {
+      // The payload (types, metadata, ordering) is built server-side by
+      // lib/sync_builder.php — the same builder the headless "Update Remote
+      // Playlist" FPP command uses, so the two paths cannot drift (#158).
+      // Server-side also keeps the POST clear of Apache's CSP for
+      // self-hosted API URLs (#157).
+      await FPPPost('/plugin.php?plugin=remote-falcon&page=sync_playlists.php&nopage=1', JSON.stringify({playlistName: selectedPlaylist, syncMetadata: shouldSyncMetadata}), async (data, statusText, xhr) => {
         if(xhr?.status === 200) {
           updateSyncProgress('Sync complete', 100);
-          REMOTE_PLAYLIST = $('#remotePlaylistSelect').val();
+          REMOTE_PLAYLIST = selectedPlaylist;
           await FPPPost('/api/plugin/remote-falcon/settings/remotePlaylist', REMOTE_PLAYLIST, async () => {
             $.jGrowl("Remote Playlist Saved", { themeState: 'success' });
             await restartListener();
           });
         }
       }, (xhr, status, error) => {
+        let message = "Error syncing playlists";
+        try {
+          const body = JSON.parse(xhr?.responseText || '{}');
+          if (body?.error === 'too_many_items') {
+            message = "Cannot sync more than 500 items";
+          } else if (body?.error === 'empty_playlist') {
+            message = "Playlist is Empty";
+          } else if (body?.error === 'playlist_fetch_failed') {
+            message = "Unable to load playlist";
+          }
+        } catch (parseError) {
+          // keep the generic message
+        }
         console.error('syncPlaylists failed:', status, error);
-        $.jGrowl("Error syncing playlists", { themeState: 'danger' });
+        $.jGrowl(message, { themeState: 'danger' });
       });
     } catch (error) {
       console.error('Sync to RF failed:', error);

--- a/lib/sync_builder.php
+++ b/lib/sync_builder.php
@@ -1,0 +1,195 @@
+<?php
+// Shared playlist-sync payload builder (issue #158).
+//
+// Single source of truth for the /syncPlaylists payload. Consumed by:
+//   - sync_playlists.php           (UI "Sync with RF" button, server-side)
+//   - commands/update_remote_playlist.php  (headless FPP command)
+//
+// Before this file existed the browser (js/remote_falcon_ui.js) and the
+// command each built their own payload and drifted: the command sent no
+// playlistType, no media metadata, and dropped command-type items. The
+// builder pins the rich shape for both callers.
+//
+// rf_build_sync_payload() and the small helpers above it are PURE (the
+// metadata fetcher is injected) — unit-tested in tests/SyncBuilderTest.php.
+// rf_sync_playlist_to_rf() is the effectful orchestrator (FPP API + RF API).
+
+if (!function_exists('rf_build_sync_payload')) {
+
+    /** Strip the last file extension: "my.song.mp3" -> "my.song". */
+    function rf_strip_file_extension(string $filename): string {
+        return preg_replace('/\.[^.]+$/', '', $filename);
+    }
+
+    /** True when $url is an http(s) URL ending in a common image extension. */
+    function rf_is_image_url(string $url): bool {
+        return preg_match('/^https?:\/\/\S+\.(png|jpe?g|gif|webp|bmp|svg)(\?\S*)?$/i', $url) === 1;
+    }
+
+    /**
+     * Extract an album-art URL from an FPP media comment tag. The tag value
+     * is often wrapped in quotes and/or has a trailing comma (ffprobe
+     * artifact). Returns "" unless the cleaned value is an image URL.
+     */
+    function rf_parse_album_art_url(?string $commentTag): string {
+        if ($commentTag === null || $commentTag === '') {
+            return '';
+        }
+        $candidate = trim($commentTag);
+        if (substr($candidate, -1) === ',') {
+            $candidate = trim(substr($candidate, 0, -1));
+        }
+        if (strlen($candidate) >= 2 && $candidate[0] === '"' && substr($candidate, -1) === '"') {
+            $candidate = trim(substr($candidate, 1, -1));
+        }
+        return rf_is_image_url($candidate) ? $candidate : '';
+    }
+
+    /**
+     * Build the /syncPlaylists payload from a decoded FPP mainPlaylist array.
+     *
+     * Mirrors the historical browser behavior exactly:
+     *  - 'both'      -> SEQUENCE (name from sequenceName); media metadata
+     *                   included only when $syncMetadata is true
+     *  - 'sequence'  -> SEQUENCE (name from sequenceName)
+     *  - 'media'     -> MEDIA, duration 0 (name from mediaName)
+     *  - 'command'   -> COMMAND, duration 0 (name from note; skipped if no note)
+     *  - anything else (pause, ...) -> skipped
+     * Skipped items still consume a playlistIndex so indexes always reflect
+     * true FPP playlist positions.
+     *
+     * @param array    $mainPlaylist  Decoded items (assoc arrays) from FPP's
+     *                                /api/playlist/<name> mainPlaylist field.
+     * @param bool     $syncMetadata  Include mediaTitle/mediaArtist/mediaAlbumUrl
+     *                                for 'both' items.
+     * @param callable $fetchMediaMeta fn(string $mediaName): ?array — decoded
+     *                                FPP /api/media/<name>/meta response, or
+     *                                null on failure.
+     * @return array List of assoc arrays matching SyncPlaylistDetails.
+     */
+    function rf_build_sync_payload(array $mainPlaylist, bool $syncMetadata, callable $fetchMediaMeta): array {
+        $sequences = [];
+        $playlistIndex = 1;
+        foreach ($mainPlaylist as $item) {
+            $type = isset($item['type']) ? $item['type'] : '';
+            if ($type === 'both') {
+                $entry = [
+                    'playlistName' => rf_strip_file_extension(isset($item['sequenceName']) ? $item['sequenceName'] : ''),
+                    'playlistDuration' => (int) (isset($item['duration']) ? $item['duration'] : 0),
+                    'playlistIndex' => $playlistIndex,
+                    'playlistType' => 'SEQUENCE',
+                ];
+                if ($syncMetadata) {
+                    $meta = $fetchMediaMeta(isset($item['mediaName']) ? $item['mediaName'] : '');
+                    $tags = isset($meta['format']['tags']) && is_array($meta['format']['tags'])
+                        ? $meta['format']['tags'] : [];
+                    $entry['mediaTitle'] = isset($tags['title']) ? (string) $tags['title'] : '';
+                    $entry['mediaArtist'] = isset($tags['artist']) ? (string) $tags['artist'] : '';
+                    $entry['mediaAlbumUrl'] = rf_parse_album_art_url(isset($tags['comment']) ? (string) $tags['comment'] : null);
+                }
+                $sequences[] = $entry;
+            } else if ($type === 'sequence') {
+                $sequences[] = [
+                    'playlistName' => rf_strip_file_extension(isset($item['sequenceName']) ? $item['sequenceName'] : ''),
+                    'playlistDuration' => (int) (isset($item['duration']) ? $item['duration'] : 0),
+                    'playlistIndex' => $playlistIndex,
+                    'playlistType' => 'SEQUENCE',
+                ];
+            } else if ($type === 'media') {
+                $sequences[] = [
+                    'playlistName' => rf_strip_file_extension(isset($item['mediaName']) ? $item['mediaName'] : ''),
+                    'playlistDuration' => 0,
+                    'playlistIndex' => $playlistIndex,
+                    'playlistType' => 'MEDIA',
+                ];
+            } else if ($type === 'command' && isset($item['note']) && $item['note'] !== null) {
+                $sequences[] = [
+                    'playlistName' => (string) $item['note'],
+                    'playlistDuration' => 0,
+                    'playlistIndex' => $playlistIndex,
+                    'playlistType' => 'COMMAND',
+                ];
+            }
+            $playlistIndex++;
+        }
+        return $sequences;
+    }
+
+    /**
+     * Hosted-service guard: remotefalcon.com caps a sync at 500 items.
+     * Self-hosted instances have no client-side cap.
+     */
+    function rf_sync_hosted_item_limit_exceeded(string $pluginsApiPath, int $totalItems): bool {
+        return strpos($pluginsApiPath, 'remotefalcon.com') !== false && $totalItems > 500;
+    }
+
+    /**
+     * Full playlist sync: fetch the playlist from the local FPP API, build
+     * the rich payload, POST it to <pluginsApiPath>/syncPlaylists.
+     *
+     * Does NOT write plugin settings or restart the listener — callers own
+     * those side effects (the command switches remotePlaylist and restarts;
+     * auto-sync re-syncs the same playlist and must NOT restart).
+     *
+     * @param string $playlistName FPP playlist to sync.
+     * @param array  $cfg          From rf_load_settings(): remoteToken,
+     *                             pluginsApiPath, raw.
+     * @param array  $opts         Optional: 'syncMetadata' (bool; default =
+     *                             the saved autoSyncMetadata setting),
+     *                             'fppBase' (string; default http://127.0.0.1).
+     * @return array ['ok' => bool, 'error' => ?string, 'count' => int]
+     */
+    function rf_sync_playlist_to_rf(string $playlistName, array $cfg, array $opts = []): array {
+        $fppBase = isset($opts['fppBase']) ? rtrim($opts['fppBase'], '/') : 'http://127.0.0.1';
+        $pluginsApiPath = rtrim($cfg['pluginsApiPath'], '/');
+        if ($pluginsApiPath === '' || strlen($cfg['remoteToken']) <= 1) {
+            return ['ok' => false, 'error' => 'no_token_or_api_path', 'count' => 0];
+        }
+
+        $raw = rf_http_request('GET', $fppBase . '/api/playlist/' . rawurlencode($playlistName), [], null, 15);
+        $playlistData = $raw !== null ? json_decode($raw, true) : null;
+        if (!is_array($playlistData) || !isset($playlistData['mainPlaylist']) || !is_array($playlistData['mainPlaylist'])) {
+            return ['ok' => false, 'error' => 'playlist_fetch_failed', 'count' => 0];
+        }
+
+        $totalItems = isset($playlistData['playlistInfo']['total_items'])
+            ? (int) $playlistData['playlistInfo']['total_items']
+            : count($playlistData['mainPlaylist']);
+        if (rf_sync_hosted_item_limit_exceeded($pluginsApiPath, $totalItems)) {
+            return ['ok' => false, 'error' => 'too_many_items', 'count' => 0];
+        }
+
+        if (isset($opts['syncMetadata'])) {
+            $syncMetadata = (bool) $opts['syncMetadata'];
+        } else {
+            $saved = isset($cfg['raw']['autoSyncMetadata']) ? urldecode($cfg['raw']['autoSyncMetadata']) : 'false';
+            $syncMetadata = ($saved === 'true');
+        }
+
+        $fetchMediaMeta = function (string $mediaName) use ($fppBase): ?array {
+            if ($mediaName === '') {
+                return null;
+            }
+            $raw = rf_http_request('GET', $fppBase . '/api/media/' . rawurlencode($mediaName) . '/meta', [], null, 10);
+            $decoded = $raw !== null ? json_decode($raw, true) : null;
+            return is_array($decoded) ? $decoded : null;
+        };
+
+        $sequences = rf_build_sync_payload($playlistData['mainPlaylist'], $syncMetadata, $fetchMediaMeta);
+        if (count($sequences) === 0) {
+            return ['ok' => false, 'error' => 'empty_playlist', 'count' => 0];
+        }
+
+        $response = rf_http_request(
+            'POST',
+            $pluginsApiPath . '/syncPlaylists',
+            ['Content-Type' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
+            json_encode(['playlists' => $sequences]),
+            30
+        );
+        if ($response === null) {
+            return ['ok' => false, 'error' => 'sync_failed', 'count' => 0];
+        }
+        return ['ok' => true, 'error' => null, 'count' => count($sequences)];
+    }
+}

--- a/sync_playlists.php
+++ b/sync_playlists.php
@@ -1,23 +1,24 @@
 <?php
-// Server-side proxy for the "Sync with RF" button.
+// Server-side sync for the "Sync with RF" button.
 //
 // Invoked same-origin via:
 //   plugin.php?plugin=remote-falcon&page=sync_playlists.php&nopage=1
 //
-// Forwards the browser-built {playlists:[...]} payload to
-// <pluginsApiPath>/syncPlaylists from the FPP server, so the POST is not
-// blocked by FPP's Apache Content-Security-Policy for self-hosted
-// (non-remotefalcon.com) API URLs. See remote-falcon-issue-tracker#157.
+// The browser sends {playlistName, syncMetadata} and this page builds the
+// full rich payload via the shared builder (lib/sync_builder.php) and POSTs
+// it to <pluginsApiPath>/syncPlaylists — the same builder the headless
+// "Remote Falcon - Update Remote Playlist" command uses, so the two sync
+// paths can no longer drift (issue #158). Running server-side also keeps the
+// POST clear of FPP's Apache Content-Security-Policy for self-hosted API
+// URLs (issue #157).
 //
-// This is a transparent pass-through: the browser remains the source of truth
-// for the payload (playlist types, media title/artist, album art, ordering).
-// The headless "Remote Falcon - Update Remote Playlist" FPP command builds a
-// thinner payload and is intentionally NOT touched here — the two sync paths
-// have drifted and reconciling them is tracked separately.
+// Back-compat: a legacy {playlists:[...]} body (browser-built payload from a
+// cached pre-#158 remote_falcon_ui.js) is still forwarded verbatim.
 //
 // Must be requested with &nopage=1 (see health_check.php for why).
 
 require_once __DIR__ . '/lib/listener_http.php';
+require_once __DIR__ . '/lib/sync_builder.php';
 require_once __DIR__ . '/commands/_lib.php';
 
 header('Content-Type: application/json');
@@ -37,26 +38,49 @@ if ($base === '') {
 }
 
 $input = json_decode(file_get_contents('php://input'), true);
-if (!is_array($input) || !isset($input['playlists']) || !is_array($input['playlists'])) {
+if (!is_array($input)) {
     http_response_code(400);
     echo json_encode(['ok' => false, 'error' => 'invalid_payload']);
     exit;
 }
 
-$payload = json_encode(['playlists' => $input['playlists']]);
-
-$response = rf_http_request(
-    'POST',
-    $base . '/syncPlaylists',
-    ['Content-Type' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
-    $payload,
-    30
-);
-
-if ($response === null) {
-    http_response_code(502);
-    echo json_encode(['ok' => false, 'error' => 'sync_failed']);
+// Legacy pass-through: browser-built payload from a cached pre-#158 UI.
+if (isset($input['playlists']) && is_array($input['playlists'])) {
+    $response = rf_http_request(
+        'POST',
+        $base . '/syncPlaylists',
+        ['Content-Type' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
+        json_encode(['playlists' => $input['playlists']]),
+        30
+    );
+    if ($response === null) {
+        http_response_code(502);
+        echo json_encode(['ok' => false, 'error' => 'sync_failed']);
+        exit;
+    }
+    echo json_encode(['ok' => true, 'count' => count($input['playlists'])]);
     exit;
 }
 
-echo json_encode(['ok' => true]);
+if (!isset($input['playlistName']) || !is_string($input['playlistName']) || $input['playlistName'] === '') {
+    http_response_code(400);
+    echo json_encode(['ok' => false, 'error' => 'invalid_payload']);
+    exit;
+}
+
+$opts = [];
+if (isset($input['syncMetadata'])) {
+    $opts['syncMetadata'] = (bool) $input['syncMetadata'];
+}
+
+$result = rf_sync_playlist_to_rf($input['playlistName'], $cfg, $opts);
+
+if (!$result['ok']) {
+    // playlist_fetch_failed / empty_playlist / too_many_items are caller
+    // errors; sync_failed means the RF API didn't answer.
+    http_response_code($result['error'] === 'sync_failed' ? 502 : 400);
+    echo json_encode(['ok' => false, 'error' => $result['error']]);
+    exit;
+}
+
+echo json_encode(['ok' => true, 'count' => $result['count']]);

--- a/tests/SyncBuilderTest.php
+++ b/tests/SyncBuilderTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for the shared sync-payload builder in lib/sync_builder.php.
+ *
+ * The builder is the single source of truth for the /syncPlaylists payload
+ * (issue #158) — these tests pin its output to what the browser path
+ * historically sent (js/remote_falcon_ui.js syncPlaylistToRF), item type by
+ * item type, so the headless command and the UI can never drift again.
+ */
+final class SyncBuilderTest extends TestCase {
+
+    /** Metadata fetcher stub: returns canned FPP /api/media/<name>/meta shapes. */
+    private function metaFetcher(array $byMediaName): callable {
+        return function (string $mediaName) use ($byMediaName): ?array {
+            return $byMediaName[$mediaName] ?? null;
+        };
+    }
+
+    private function neverCalledFetcher(): callable {
+        return function (string $mediaName): ?array {
+            $this->fail('metadata fetcher must not be called');
+        };
+    }
+
+    // -------- rf_strip_file_extension --------
+
+    public function testStripFileExtension(): void {
+        $this->assertSame('song', rf_strip_file_extension('song.fseq'));
+        $this->assertSame('my.song', rf_strip_file_extension('my.song.mp3'));
+        $this->assertSame('noext', rf_strip_file_extension('noext'));
+        $this->assertSame('', rf_strip_file_extension(''));
+    }
+
+    // -------- rf_is_image_url / rf_parse_album_art_url --------
+
+    public function testIsImageUrl(): void {
+        $this->assertTrue(rf_is_image_url('https://x.com/a.png'));
+        $this->assertTrue(rf_is_image_url('http://x.com/a.JPG?size=2'));
+        $this->assertTrue(rf_is_image_url('https://x.com/a.jpeg'));
+        $this->assertFalse(rf_is_image_url('https://x.com/a.html'));
+        $this->assertFalse(rf_is_image_url('ftp://x.com/a.png'));
+        $this->assertFalse(rf_is_image_url(''));
+    }
+
+    public function testParseAlbumArtUrl_trimsTrailingCommaAndQuotes(): void {
+        $this->assertSame(
+            'https://x.com/art.png',
+            rf_parse_album_art_url('"https://x.com/art.png",')
+        );
+        $this->assertSame(
+            'https://x.com/art.png',
+            rf_parse_album_art_url('  https://x.com/art.png  ')
+        );
+    }
+
+    public function testParseAlbumArtUrl_rejectsNonImageOrEmpty(): void {
+        $this->assertSame('', rf_parse_album_art_url('not a url'));
+        $this->assertSame('', rf_parse_album_art_url(null));
+        $this->assertSame('', rf_parse_album_art_url(''));
+    }
+
+    // -------- rf_build_sync_payload: item types --------
+
+    public function testSequenceItem(): void {
+        $items = [
+            ['type' => 'sequence', 'sequenceName' => 'a.fseq', 'duration' => 30],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertSame([[
+            'playlistName' => 'a',
+            'playlistDuration' => 30,
+            'playlistIndex' => 1,
+            'playlistType' => 'SEQUENCE',
+        ]], $out);
+    }
+
+    public function testBothItem_withoutMetadata(): void {
+        $items = [
+            ['type' => 'both', 'sequenceName' => 'a.fseq', 'mediaName' => 'a.mp3', 'duration' => 42],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertSame([[
+            'playlistName' => 'a',
+            'playlistDuration' => 42,
+            'playlistIndex' => 1,
+            'playlistType' => 'SEQUENCE',
+        ]], $out);
+    }
+
+    public function testBothItem_withMetadata(): void {
+        $items = [
+            ['type' => 'both', 'sequenceName' => 'a.fseq', 'mediaName' => 'a.mp3', 'duration' => 42],
+        ];
+        $meta = $this->metaFetcher([
+            'a.mp3' => ['format' => ['tags' => [
+                'title' => 'Song A',
+                'artist' => 'Artist A',
+                'comment' => '"https://x.com/a.png",',
+            ]]],
+        ]);
+        $out = rf_build_sync_payload($items, true, $meta);
+        $this->assertSame([[
+            'playlistName' => 'a',
+            'playlistDuration' => 42,
+            'playlistIndex' => 1,
+            'playlistType' => 'SEQUENCE',
+            'mediaTitle' => 'Song A',
+            'mediaArtist' => 'Artist A',
+            'mediaAlbumUrl' => 'https://x.com/a.png',
+        ]], $out);
+    }
+
+    public function testBothItem_metadataFetchFailsFallsBackToEmptyFields(): void {
+        $items = [
+            ['type' => 'both', 'sequenceName' => 'a.fseq', 'mediaName' => 'a.mp3', 'duration' => 42],
+        ];
+        $out = rf_build_sync_payload($items, true, $this->metaFetcher([]));
+        $this->assertSame([[
+            'playlistName' => 'a',
+            'playlistDuration' => 42,
+            'playlistIndex' => 1,
+            'playlistType' => 'SEQUENCE',
+            'mediaTitle' => '',
+            'mediaArtist' => '',
+            'mediaAlbumUrl' => '',
+        ]], $out);
+    }
+
+    public function testMediaItem_durationIsZeroAndNameFromMedia(): void {
+        $items = [
+            ['type' => 'media', 'mediaName' => 'track.mp3', 'duration' => 180],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertSame([[
+            'playlistName' => 'track',
+            'playlistDuration' => 0,
+            'playlistIndex' => 1,
+            'playlistType' => 'MEDIA',
+        ]], $out);
+    }
+
+    public function testCommandItem_usesNoteAsName(): void {
+        $items = [
+            ['type' => 'command', 'note' => 'Fog On', 'duration' => 5],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertSame([[
+            'playlistName' => 'Fog On',
+            'playlistDuration' => 0,
+            'playlistIndex' => 1,
+            'playlistType' => 'COMMAND',
+        ]], $out);
+    }
+
+    public function testCommandItem_withoutNoteIsSkippedButStillConsumesIndex(): void {
+        $items = [
+            ['type' => 'command', 'duration' => 5],
+            ['type' => 'sequence', 'sequenceName' => 'b.fseq', 'duration' => 10],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        // Matches the browser behavior: the unsyncable item is skipped but
+        // playlistIndex still reflects the FPP playlist position.
+        $this->assertCount(1, $out);
+        $this->assertSame('b', $out[0]['playlistName']);
+        $this->assertSame(2, $out[0]['playlistIndex']);
+    }
+
+    public function testUnknownItemTypeIsSkipped(): void {
+        $items = [
+            ['type' => 'pause', 'duration' => 10],
+            ['type' => 'sequence', 'sequenceName' => 'b.fseq', 'duration' => 10],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertCount(1, $out);
+        $this->assertSame(2, $out[0]['playlistIndex']);
+    }
+
+    public function testMixedPlaylist_indexesAreSequentialFppPositions(): void {
+        $items = [
+            ['type' => 'sequence', 'sequenceName' => 'a.fseq', 'duration' => 30],
+            ['type' => 'media', 'mediaName' => 'b.mp3', 'duration' => 200],
+            ['type' => 'command', 'note' => 'PSA', 'duration' => 1],
+            ['type' => 'both', 'sequenceName' => 'd.fseq', 'mediaName' => 'd.mp3', 'duration' => 60],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertSame(['a', 'b', 'PSA', 'd'], array_column($out, 'playlistName'));
+        $this->assertSame([1, 2, 3, 4], array_column($out, 'playlistIndex'));
+        $this->assertSame(['SEQUENCE', 'MEDIA', 'COMMAND', 'SEQUENCE'], array_column($out, 'playlistType'));
+    }
+
+    public function testEmptyPlaylistReturnsEmptyArray(): void {
+        $this->assertSame([], rf_build_sync_payload([], true, $this->neverCalledFetcher()));
+    }
+
+    public function testFloatDurationIsTruncatedToInt(): void {
+        $items = [
+            ['type' => 'sequence', 'sequenceName' => 'a.fseq', 'duration' => 30.7],
+        ];
+        $out = rf_build_sync_payload($items, false, $this->neverCalledFetcher());
+        $this->assertSame(30, $out[0]['playlistDuration']);
+    }
+
+    // -------- rf_sync_hosted_item_limit_exceeded --------
+
+    public function testHostedItemLimit(): void {
+        $this->assertTrue(rf_sync_hosted_item_limit_exceeded('https://remotefalcon.com/remote-falcon-plugins-api', 501));
+        $this->assertFalse(rf_sync_hosted_item_limit_exceeded('https://remotefalcon.com/remote-falcon-plugins-api', 500));
+        // Self-hosted: no cap.
+        $this->assertFalse(rf_sync_hosted_item_limit_exceeded('https://myshow.example.com/plugins-api', 9999));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,5 +8,6 @@ require_once __DIR__ . '/../lib/listener_logic.php';
 require_once __DIR__ . '/../lib/listener_http.php';
 require_once __DIR__ . '/../lib/listener_log.php';
 require_once __DIR__ . '/../lib/listener_actions.php';
+require_once __DIR__ . '/../lib/sync_builder.php';
 require_once __DIR__ . '/integration/MockServer.php';
 require_once __DIR__ . '/integration/IntegrationTestCase.php';


### PR DESCRIPTION
## Summary
Closes #158.

The UI "Sync with RF" button and the headless "Update Remote Playlist" FPP command each built their own /syncPlaylists payload — in different languages — and drifted: the command sent no `playlistType`, no media title/artist/album-art, and dropped command-type items, so any scheduled/automated re-sync silently degraded the show's sequence data.

## What changed
- New `lib/sync_builder.php` — the single payload builder. Pure build function (metadata fetcher injected) + `rf_sync_playlist_to_rf()` orchestrator (fetch playlist from local FPP API, hosted 500-item cap, POST to plugins-api).
- `commands/update_remote_playlist.php` now uses the builder — same rich payload as the UI, honors the saved *Auto Sync Metadata* setting, keeps the remotePlaylist-save + listener-restart behavior.
- `sync_playlists.php` (UI path) now builds server-side too — browser sends `{playlistName, syncMetadata}`; the old browser-built `{playlists:[...]}` shape is still accepted for cached JS. Removes the last browser-side payload logic (and its CSP exposure for self-hosters, same class as #157).
- `js/remote_falcon_ui.js` — sync fn reduced to a thin trigger; dead payload helpers removed so the drift can't return. The #137 dot-preserving filename behavior is ported and tested.

## Testing
16 new unit tests (`tests/SyncBuilderTest.php`) pin the payload shape per item type against the historical browser behavior. Full suite green.