### PR TITLE
feat: opt-in auto sync of playlist changes with 30s quiet-window debounce (#13)

### DIFF
--- a/js/remote_falcon_core.js
+++ b/js/remote_falcon_core.js
@@ -13,6 +13,7 @@ var REMOTE_PLAYLIST = null;
 var PLUGINS_API_PATH = DEFAULT_PLUGINS_API_PATH;
 var VERBOSE_LOGGING = null;
 var AUTO_SYNC_METADATA = false;
+var AUTO_SYNC_PLAYLIST = false;
 
 async function saveDefaultPluginConfig() {
   await FPPGet('/api/plugin/remote-falcon/settings/init', async (data) => {
@@ -31,6 +32,7 @@ async function saveDefaultPluginConfig() {
         FPPPost('/api/plugin/remote-falcon/settings/pluginsApiPath', PLUGINS_API_PATH, noop),
         FPPPost('/api/plugin/remote-falcon/settings/verboseLogging', 'false', noop),
         FPPPost('/api/plugin/remote-falcon/settings/autoSyncMetadata', 'false', noop),
+        FPPPost('/api/plugin/remote-falcon/settings/autoSyncPlaylist', 'false', noop),
       ]);
       $.jGrowl("Default Config Saved", { themeState: 'success' });
     }
@@ -88,6 +90,9 @@ async function getPluginConfig() {
     }),
     FPPGet('/api/plugin/remote-falcon/settings/autoSyncMetadata', (data) => {
       AUTO_SYNC_METADATA = data?.autoSyncMetadata == 'true';
+    }),
+    FPPGet('/api/plugin/remote-falcon/settings/autoSyncPlaylist', (data) => {
+      AUTO_SYNC_PLAYLIST = data?.autoSyncPlaylist == 'true';
     }),
   ]);
   await getRemotePlaylistFromConfig();

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -13,6 +13,7 @@ $(document).ready(async () => {
   $('#pluginsApiPathInput').val(PLUGINS_API_PATH);
   $('#verboseLoggingCheckbox').prop('checked', VERBOSE_LOGGING);
   $('#autoSyncMetadataCheckbox').prop('checked', AUTO_SYNC_METADATA);
+  $('#autoSyncPlaylistCheckbox').prop('checked', AUTO_SYNC_PLAYLIST);
 
   //Component Handlers
   $('#remoteTokenInput').blur(async () => {
@@ -114,6 +115,16 @@ $(document).ready(async () => {
     AUTO_SYNC_METADATA = isChecked;
     await FPPPost('/api/plugin/remote-falcon/settings/autoSyncMetadata', isChecked.toString(), () => {
       $.jGrowl(isChecked ? "Metadata sync enabled" : "Metadata sync disabled", { themeState: 'success' });
+    });
+  });
+
+  // The listener re-reads settings each tick (INI mtime watch), so this
+  // toggle takes effect without a listener restart.
+  $('#autoSyncPlaylistCheckbox').change(async () => {
+    const isChecked = $('#autoSyncPlaylistCheckbox').is(':checked');
+    AUTO_SYNC_PLAYLIST = isChecked;
+    await FPPPost('/api/plugin/remote-falcon/settings/autoSyncPlaylist', isChecked.toString(), () => {
+      $.jGrowl(isChecked ? "Auto playlist sync enabled" : "Auto playlist sync disabled", { themeState: 'success' });
     });
   });
 
@@ -526,7 +537,8 @@ additionalWaitTime = "0"
 fppStatusCheckTime = "1"
 pluginsApiPath = "${DEFAULT_PLUGINS_API_PATH}"
 verboseLogging = "false"
-autoSyncMetadata = "false"`;
+autoSyncMetadata = "false"
+autoSyncPlaylist = "false"`;
 
   $('#pluginConfigTextarea').val(defaultConfig);
 

--- a/lib/listener_logic.php
+++ b/lib/listener_logic.php
@@ -263,4 +263,45 @@ if (!function_exists('rf_get_next_sequence')) {
         $mtime = @filemtime($path);
         return $mtime === false ? null : $mtime;
     }
+
+    /**
+     * Auto Sync Playlist decision (issue #13): should the listener re-sync
+     * the remote playlist to RF on this tick?
+     *
+     * A sync fires only after the playlist file's mtime has changed AND then
+     * held unchanged for the full $quietSeconds window. Every further change
+     * resets the window, so an active editing session in the FPP UI
+     * coalesces into a single sync shortly after the last save — the
+     * listener never syncs mid-edit.
+     *
+     * State machine over ($prevMtime, $changedAt):
+     *   - file missing            -> clear state, never sync
+     *   - first observation       -> baseline (no sync on listener start)
+     *   - mtime changed           -> remember it, (re)start the quiet window
+     *   - stable & window elapsed -> SYNC, close the window
+     *   - otherwise               -> wait
+     *
+     * @param ?int      $prevMtime    Last observed mtime (null = none yet).
+     * @param ?int      $changedAt    Timestamp when the pending change was
+     *                                first observed (null = no pending change).
+     * @param int|false|null $currMtime Current filemtime() result.
+     * @param int       $now          Current unix timestamp.
+     * @param int       $quietSeconds Quiet window; production uses 30.
+     * @return array ['sync' => bool, 'lastMtime' => ?int, 'changedAt' => ?int]
+     */
+    function rf_auto_sync_decision(?int $prevMtime, ?int $changedAt, $currMtime, int $now, int $quietSeconds = 30): array {
+        if ($currMtime === false || $currMtime === null) {
+            return ['sync' => false, 'lastMtime' => null, 'changedAt' => null];
+        }
+        if ($prevMtime === null) {
+            return ['sync' => false, 'lastMtime' => $currMtime, 'changedAt' => null];
+        }
+        if ($currMtime !== $prevMtime) {
+            return ['sync' => false, 'lastMtime' => $currMtime, 'changedAt' => $now];
+        }
+        if ($changedAt !== null && ($now - $changedAt) >= $quietSeconds) {
+            return ['sync' => true, 'lastMtime' => $currMtime, 'changedAt' => null];
+        }
+        return ['sync' => false, 'lastMtime' => $currMtime, 'changedAt' => $changedAt];
+    }
 }

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -20,6 +20,7 @@ require_once __DIR__ . "/lib/listener_logic.php";
 require_once __DIR__ . "/lib/listener_http.php";
 require_once __DIR__ . "/lib/listener_log.php";
 require_once __DIR__ . "/lib/listener_actions.php";
+require_once __DIR__ . "/lib/sync_builder.php";
 $pluginName = basename(dirname(__FILE__));
 $pluginPath = $settings['pluginDirectory']."/".$pluginName."/";
 $logFile = $settings['logDirectory']."/".$pluginName."-listener.log";
@@ -66,6 +67,9 @@ if (strlen(urldecode($pluginSettings['remoteFalconListenerEnabled']))<1){
 if (strlen(urldecode($pluginSettings['remoteFalconListenerRestarting']))<1){
   WriteSettingToFile("remoteFalconListenerRestarting",urlencode("false"),$pluginName);
 }
+if (!isset($pluginSettings['autoSyncPlaylist']) || strlen(urldecode($pluginSettings['autoSyncPlaylist']))<1){
+  WriteSettingToFile("autoSyncPlaylist",urlencode("false"),$pluginName);
+}
 
 $remoteToken = "";
 $remotePlaylist = "";
@@ -80,6 +84,12 @@ $pluginsApiPath = "";
 $verboseLogging = false;
 $lastQueuedSequence = "";
 $lastQueuedTime = 0;
+
+// Auto Sync Playlist (#13) watcher state.
+$autoSyncPlaylistName = null;
+$autoSyncLastMtime = null;
+$autoSyncChangedAt = null;
+$autoSyncMissingWarned = false;
 
 $pluginsApiPath = urldecode($pluginSettings['pluginsApiPath']);
 logEntry("Plugins API Path: " . $pluginsApiPath);
@@ -191,6 +201,49 @@ while(true) {
     if (($nowTs - $lastHeartbeatTs) >= $heartbeatIntervalSeconds) {
       fppHeartbeat($remoteToken);
       $lastHeartbeatTs = $nowTs;
+    }
+
+    // Auto Sync Playlist (#13): watch the synced playlist's JSON for edits
+    // and re-sync to RF once the file has sat quiet for 30s (every new save
+    // resets the window, so an editing session coalesces into one sync).
+    // Off by default via the autoSyncPlaylist setting. Re-syncs the SAME
+    // playlist, so no listener restart and no remotePlaylist rewrite.
+    $autoSyncEnabled = isset($pluginSettings['autoSyncPlaylist'])
+        && urldecode($pluginSettings['autoSyncPlaylist']) === "true";
+    if ($autoSyncEnabled && $remotePlaylist != "") {
+      if ($autoSyncPlaylistName !== $remotePlaylist) {
+        // Synced playlist switched (UI or command) — start fresh, don't
+        // treat the new file's mtime as a pending change.
+        $autoSyncPlaylistName = $remotePlaylist;
+        $autoSyncLastMtime = null;
+        $autoSyncChangedAt = null;
+        $autoSyncMissingWarned = false;
+      }
+      $playlistDir = isset($settings['playlistDirectory']) ? $settings['playlistDirectory'] : '/home/fpp/media/playlists';
+      $playlistJson = $playlistDir . '/' . $remotePlaylist . '.json';
+      $currMtime = @filemtime($playlistJson);
+      if ($currMtime === false && !$autoSyncMissingWarned) {
+        logEntry("WARNING - Auto Sync: playlist file not found: " . $playlistJson);
+        $autoSyncMissingWarned = true;
+      } else if ($currMtime !== false) {
+        $autoSyncMissingWarned = false;
+      }
+      $autoSyncDecision = rf_auto_sync_decision($autoSyncLastMtime, $autoSyncChangedAt, $currMtime, $nowTs, 30);
+      $autoSyncLastMtime = $autoSyncDecision['lastMtime'];
+      $autoSyncChangedAt = $autoSyncDecision['changedAt'];
+      if ($autoSyncDecision['sync']) {
+        logEntry("Auto Sync: '" . $remotePlaylist . "' changed; re-syncing to Remote Falcon");
+        $autoSyncResult = rf_sync_playlist_to_rf($remotePlaylist, [
+          'remoteToken' => $remoteToken,
+          'pluginsApiPath' => $pluginsApiPath,
+          'raw' => $pluginSettings,
+        ]);
+        if ($autoSyncResult['ok']) {
+          logEntry("Auto Sync: synced " . $autoSyncResult['count'] . " items");
+        } else {
+          logEntry("ERROR - Auto Sync failed: " . $autoSyncResult['error']);
+        }
+      }
     }
 
     // Per-tick "Getting FPP Status" log was previously emitted at verbose

--- a/remote_falcon_ui.html
+++ b/remote_falcon_ui.html
@@ -86,6 +86,10 @@
               <input class="form-check-input" type="checkbox" id="autoSyncMetadataCheckbox">
               <label class="form-check-label" for="autoSyncMetadataCheckbox">Sync metadata (title/artist/comment)</label>
             </div>
+            <div class="form-check auto-sync-check">
+              <input class="form-check-input" type="checkbox" id="autoSyncPlaylistCheckbox">
+              <label class="form-check-label" for="autoSyncPlaylistCheckbox">Auto sync playlist changes to RF</label>
+            </div>
             <button id="syncRemotePlaylistButton" class="buttons btn-outline-success btn-rounded button-margin" type="button">Sync with RF</button>
           </div>
         </div>

--- a/tests/AutoSyncDecisionTest.php
+++ b/tests/AutoSyncDecisionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for rf_auto_sync_decision() — the pure state machine behind
+ * Auto Sync Playlist (issue #13).
+ *
+ * Contract: a sync fires only after the playlist file's mtime has changed
+ * AND then held unchanged for the full quiet window (30 s in production).
+ * Every further change resets the window, so an active editing session in
+ * the FPP UI coalesces into a single sync after the last save.
+ */
+final class AutoSyncDecisionTest extends TestCase {
+
+    private const QUIET = 30;
+
+    public function testFirstObservationBaselinesWithoutSyncing(): void {
+        $d = rf_auto_sync_decision(null, null, 1000, 5000, self::QUIET);
+        $this->assertFalse($d['sync']);
+        $this->assertSame(1000, $d['lastMtime']);
+        $this->assertNull($d['changedAt']);
+    }
+
+    public function testChangeDetectedStartsQuietWindowWithoutSyncing(): void {
+        $d = rf_auto_sync_decision(1000, null, 1010, 5000, self::QUIET);
+        $this->assertFalse($d['sync']);
+        $this->assertSame(1010, $d['lastMtime']);
+        $this->assertSame(5000, $d['changedAt']);
+    }
+
+    public function testStableButWindowNotElapsedDoesNotSync(): void {
+        $d = rf_auto_sync_decision(1010, 5000, 1010, 5029, self::QUIET);
+        $this->assertFalse($d['sync']);
+        $this->assertSame(5000, $d['changedAt']);
+    }
+
+    public function testStableForFullQuietWindowSyncs(): void {
+        $d = rf_auto_sync_decision(1010, 5000, 1010, 5030, self::QUIET);
+        $this->assertTrue($d['sync']);
+        $this->assertSame(1010, $d['lastMtime']);
+        $this->assertNull($d['changedAt']);
+    }
+
+    public function testNewChangeDuringQuietWindowResetsTheWindow(): void {
+        // Saved again 20s into the window: no sync, window restarts.
+        $d = rf_auto_sync_decision(1010, 5000, 1020, 5020, self::QUIET);
+        $this->assertFalse($d['sync']);
+        $this->assertSame(1020, $d['lastMtime']);
+        $this->assertSame(5020, $d['changedAt']);
+        // ...and only fires 30s after THAT save.
+        $d2 = rf_auto_sync_decision($d['lastMtime'], $d['changedAt'], 1020, 5050, self::QUIET);
+        $this->assertTrue($d2['sync']);
+    }
+
+    public function testSteadyStateAfterSyncDoesNothing(): void {
+        $d = rf_auto_sync_decision(1010, null, 1010, 9000, self::QUIET);
+        $this->assertFalse($d['sync']);
+        $this->assertSame(1010, $d['lastMtime']);
+        $this->assertNull($d['changedAt']);
+    }
+
+    public function testMissingFileClearsStateWithoutSyncing(): void {
+        foreach ([null, false] as $missing) {
+            $d = rf_auto_sync_decision(1010, 5000, $missing, 5030, self::QUIET);
+            $this->assertFalse($d['sync']);
+            $this->assertNull($d['lastMtime']);
+            $this->assertNull($d['changedAt']);
+        }
+    }
+
+    public function testFileReappearingBaselinesWithoutSyncing(): void {
+        // Gone...
+        $d = rf_auto_sync_decision(1010, null, null, 6000, self::QUIET);
+        // ...back: treated as a fresh baseline, not a change.
+        $d2 = rf_auto_sync_decision($d['lastMtime'], $d['changedAt'], 2000, 6010, self::QUIET);
+        $this->assertFalse($d2['sync']);
+        $this->assertSame(2000, $d2['lastMtime']);
+        $this->assertNull($d2['changedAt']);
+    }
+
+    public function testFullLifecycle(): void {
+        $mtime = 1000; $state = ['lastMtime' => null, 'changedAt' => null];
+        $step = function (int $now, int $m) use (&$state) {
+            $state = rf_auto_sync_decision($state['lastMtime'], $state['changedAt'], $m, $now, self::QUIET);
+            return $state['sync'];
+        };
+        $this->assertFalse($step(100, $mtime));          // baseline
+        $this->assertFalse($step(101, $mtime));          // steady
+        $this->assertFalse($step(102, $mtime = 1050));   // edit
+        $this->assertFalse($step(110, $mtime = 1058));   // edit again
+        $this->assertFalse($step(130, $mtime));          // quiet, 20s in
+        $this->assertTrue($step(140, $mtime));           // quiet >= 30s -> sync
+        $this->assertFalse($step(141, $mtime));          // steady again
+    }
+}


### PR DESCRIPTION
## Summary
Closes #13. **Stacked on #108** — after #108 merges to the release branch, this PR's base should be retargeted to `release/2026.07.16` (GitHub usually does this automatically).

Operators forget to re-sync after editing their playlist in FPP. This adds an opt-in watcher: when enabled, the listener stats the synced playlist's JSON each tick and re-syncs to RF once the file has sat unchanged for **30 seconds** — every new save resets the window, so an active editing session coalesces into a single sync shortly after the last save. Never syncs mid-edit.

## What changed
- `autoSyncPlaylist` setting, **default off**; checkbox in the plugin UI next to the metadata toggle. Takes effect without a listener restart (the loop re-reads settings on INI mtime change).
- Listener: `rf_auto_sync_decision()` pure state machine + loop integration. Re-syncs the *same* playlist via the #158 shared builder — no listener restart, no `remotePlaylist` rewrite. Re-baselines when the synced playlist is switched; warns once if the playlist file is missing; failed syncs log and wait for the next change (no retry loop).

## Why after #158
Without the shared builder, every auto-sync would re-apply the degraded command payload and silently wipe metadata on each edit.

## Testing
9 unit tests (`tests/AutoSyncDecisionTest.php`) covering baseline, debounce, window reset, missing file, and a full edit-session lifecycle. Full suite green on the stack.