### PR TITLE
feat: Set Active Viewer Page command with live page-name dropdown (#68)

### DIFF
--- a/commands/descriptions.json
+++ b/commands/descriptions.json
@@ -38,6 +38,19 @@
     ]
   },
   {
+    "name": "Remote Falcon - Set Active Viewer Page",
+    "script": "set_active_viewer_page.php",
+    "args": [
+      {
+        "name": "pageName",
+        "type": "string",
+        "description": "Viewer Page Name",
+        "contentListUrl": "plugin.php?plugin=remote-falcon&page=viewer_pages_list.php&nopage=1",
+        "optional": false
+      }
+    ]
+  },
+  {
     "name": "Remote Falcon - Turn Viewer Control Off",
     "script": "viewer_control_off.php",
     "args": []

--- a/commands/set_active_viewer_page.php
+++ b/commands/set_active_viewer_page.php
@@ -1,0 +1,55 @@
+#!/usr/bin/env php
+<?php
+// FPP command: "Remote Falcon - Set Active Viewer Page" (PRD-016 / issue #68)
+//
+// Makes the named viewer page the live one in Remote Falcon. Schedulable via
+// FPP Scheduler (e.g. a different page on different days) or usable from any
+// FPP command preset/event. The page-name arg is a dropdown fed by
+// viewer_pages_list.php at authoring time; the saved schedule stores the name
+// string, so a page renamed in RF needs its schedule entry re-picked.
+//
+// A no-match fails loudly: the RF API returns the list of valid page names
+// and we echo it, so the mistake is visible in the FPP command/schedule log.
+
+$skipJSsettings = true;
+include_once "/opt/fpp/www/config.php";
+include_once "/opt/fpp/www/common.php";
+include_once __DIR__ . "/_lib.php";
+require_once __DIR__ . "/../lib/listener_http.php";
+
+$pageName = isset($argv[1]) ? trim($argv[1]) : '';
+if ($pageName === '') {
+    echo "No viewer page name given\n";
+    exit(1);
+}
+
+$cfg = rf_load_settings();
+if ($cfg === null || strlen($cfg['remoteToken']) <= 1) {
+    echo "Remote Token Missing\n";
+    exit(1);
+}
+
+$result = rf_http_request_with_status(
+    'POST',
+    rtrim($cfg['pluginsApiPath'], '/') . '/setActiveViewerPage',
+    ['Content-Type' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
+    json_encode(['pageName' => $pageName]),
+    15
+);
+
+if ($result['body'] === null) {
+    echo "Set Active Viewer Page failed: no response from Remote Falcon API\n";
+    exit(1);
+}
+
+$decoded = json_decode($result['body'], true);
+$message = is_array($decoded) && isset($decoded['message']) ? $decoded['message'] : '';
+if ($result['status'] >= 200 && $result['status'] < 300 && $message === 'Success') {
+    echo "Active viewer page set to '" . $pageName . "'\n";
+} else {
+    // 4xx bodies (unknown page name, etc.) include the valid names, so the
+    // typo is debuggable straight from the FPP command/schedule log.
+    echo "Set Active Viewer Page failed: " . ($message !== '' ? $message : $result['body']) . "\n";
+    exit(1);
+}
+?>

--- a/lib/listener_http.php
+++ b/lib/listener_http.php
@@ -13,10 +13,13 @@
 if (!function_exists('rf_http_request')) {
 
     /**
-     * Issue a single HTTP request and return the response body, or null
-     * on transport error / timeout / non-2xx response.
+     * Issue a single HTTP request and return ['status' => int, 'body' => ?string].
+     * On transport error / timeout: status 0, body null. Non-2xx responses
+     * return their real status and body — callers that need error bodies
+     * (e.g. a 400 listing valid values) use this directly; everything else
+     * goes through rf_http_request() below.
      */
-    function rf_http_request(string $method, string $url, array $headers = [], ?string $body = null, int $timeout = 10): ?string {
+    function rf_http_request_with_status(string $method, string $url, array $headers = [], ?string $body = null, int $timeout = 10): array {
         $headerLines = [];
         foreach ($headers as $name => $value) {
             $headerLines[] = "$name: $value";
@@ -35,7 +38,7 @@ if (!function_exists('rf_http_request')) {
         $context = stream_context_create($opts);
         $response = @file_get_contents($url, false, $context);
         if ($response === false) {
-            return null;
+            return ['status' => 0, 'body' => null];
         }
         // Read response headers. PHP 8.4+ exposes http_get_last_response_headers();
         // older versions only expose the locally scoped $http_response_header,
@@ -53,10 +56,19 @@ if (!function_exists('rf_http_request')) {
                 $statusCode = (int) $m[1];
             }
         }
-        if ($statusCode < 200 || $statusCode >= 300) {
+        return ['status' => $statusCode, 'body' => $response];
+    }
+
+    /**
+     * Issue a single HTTP request and return the response body, or null
+     * on transport error / timeout / non-2xx response.
+     */
+    function rf_http_request(string $method, string $url, array $headers = [], ?string $body = null, int $timeout = 10): ?string {
+        $result = rf_http_request_with_status($method, $url, $headers, $body, $timeout);
+        if ($result['body'] === null || $result['status'] < 200 || $result['status'] >= 300) {
             return null;
         }
-        return $response;
+        return $result['body'];
     }
 
     /**

--- a/tests/integration/ListenerHttpTest.php
+++ b/tests/integration/ListenerHttpTest.php
@@ -178,6 +178,34 @@ final class ListenerHttpTest extends IntegrationTestCase {
         $this->assertNull($result);
     }
 
+    public function testHttpRequestWithStatus_returnsStatusAndBodyOn2xx(): void {
+        $this->rfMock->setRoute('/setActiveViewerPage', ['body' => ['message' => 'Success']]);
+        $result = rf_http_request_with_status('POST', $this->rfMock->getBaseUrl() . '/setActiveViewerPage',
+            ['Content-Type' => 'application/json'], '{"pageName":"Main"}', 5);
+        $this->assertSame(200, $result['status']);
+        $this->assertSame('Success', json_decode($result['body'], true)['message']);
+    }
+
+    public function testHttpRequestWithStatus_preservesErrorBodyOn4xx(): void {
+        // The Set Active Viewer Page command relies on the 400 body reaching
+        // the FPP log (it lists the valid page names) — rf_http_request()
+        // would swallow it, rf_http_request_with_status() must not.
+        $this->rfMock->setRoute('/setActiveViewerPage', [
+            'status' => 400,
+            'body' => ['message' => "No viewer page named 'Easter'. Available: Main, Halloween"],
+        ]);
+        $result = rf_http_request_with_status('POST', $this->rfMock->getBaseUrl() . '/setActiveViewerPage',
+            ['Content-Type' => 'application/json'], '{"pageName":"Easter"}', 5);
+        $this->assertSame(400, $result['status']);
+        $this->assertStringContainsString('Halloween', $result['body']);
+    }
+
+    public function testHttpRequestWithStatus_returnsStatusZeroAndNullBodyOnNetworkFailure(): void {
+        $result = rf_http_request_with_status('GET', 'http://127.0.0.1:1', [], null, 1);
+        $this->assertSame(0, $result['status']);
+        $this->assertNull($result['body']);
+    }
+
     public function testHttpDecodeJson_handlesNullInput(): void {
         $this->assertNull(rf_http_decode_json(null));
     }

--- a/viewer_pages_list.php
+++ b/viewer_pages_list.php
@@ -1,0 +1,51 @@
+<?php
+// Dropdown feeder for the "Remote Falcon - Set Active Viewer Page" FPP
+// command (PRD-016 / issue #68).
+//
+// Invoked same-origin by FPP's command-args UI via contentListUrl:
+//   plugin.php?plugin=remote-falcon&page=viewer_pages_list.php&nopage=1
+//
+// Fetches the show's viewer pages from <pluginsApiPath>/viewerPages
+// (server-side, so it's clear of FPP's Apache CSP for self-hosted API URLs —
+// see remote-falcon-issue-tracker#157) and emits a plain JSON array of page
+// names. FPP's contentListUrl handler (www/js/fpp.js) expects either a plain
+// array (value == label) or a key/value object map — a plain array matches
+// what /api/playlists returns for the Update Remote Playlist command.
+//
+// On any failure emit [] — FPP renders an empty dropdown rather than erroring.
+//
+// Must be requested with &nopage=1 (see health_check.php for why).
+
+require_once __DIR__ . '/lib/listener_http.php';
+require_once __DIR__ . '/commands/_lib.php';
+
+header('Content-Type: application/json');
+
+$cfg = rf_load_settings();
+if ($cfg === null || strlen($cfg['remoteToken']) <= 1 || rtrim($cfg['pluginsApiPath'], '/') === '') {
+    echo json_encode([]);
+    exit;
+}
+
+$response = rf_http_request(
+    'GET',
+    rtrim($cfg['pluginsApiPath'], '/') . '/viewerPages',
+    ['Accept' => 'application/json', 'remotetoken' => $cfg['remoteToken']],
+    null,
+    10
+);
+
+$decoded = $response !== null ? json_decode($response, true) : null;
+if (!is_array($decoded) || !isset($decoded['pages']) || !is_array($decoded['pages'])) {
+    echo json_encode([]);
+    exit;
+}
+
+$names = [];
+foreach ($decoded['pages'] as $page) {
+    if (is_array($page) && isset($page['name']) && is_string($page['name']) && $page['name'] !== '') {
+        $names[] = $page['name'];
+    }
+}
+
+echo json_encode($names);


### PR DESCRIPTION
## Summary
Closes #68 (PRD-016). Adds an FPP command "Remote Falcon - Set Active Viewer Page" that makes the named viewer page live in RF. Schedulable via FPP Scheduler (different page on different days — the original user ask) or from any command preset/event.

## What changed
- `commands/set_active_viewer_page.php` — POSTs `{pageName}` to the new plugins-api `/setActiveViewerPage` endpoint. Fails loudly: a 400 (unknown page) echoes the API's message listing the valid page names into the FPP log.
- `viewer_pages_list.php` — dropdown feeder: fetches `GET /viewerPages` server-side (CSP-safe, #157 pattern) and emits a plain JSON string array — the shape FPP's `contentListUrl` handler expects (verified against fpp.js; same as `api/playlists`).
- `descriptions.json` — command registration with the `contentListUrl` dropdown arg.
- `lib/listener_http.php` — extracted `rf_http_request_with_status()` so error bodies survive to the caller; `rf_http_request()` reimplemented on top, behavior unchanged.

## Depends on
The plugins-api side (Remote-Falcon/remote-falcon-platform: `feat/plugins-api-set-active-viewer-page`) must be deployed before this ships to users — the command 404s against an older API.

## Known limit (documented in PRD-016)
Saved FPP schedules store the page-name string picked at authoring time; renaming the page in RF breaks that entry loudly until re-picked.

## Testing
3 new integration tests for the status-preserving HTTP helper (the 400-body pass-through the command relies on). Endpoint behavior verified live against a local plugins-api + Mongo. Full suite green.