### PR TITLE
fix: address 2026-07-16 release review findings

### DIFF
--- a/auto_sync_runner.php
+++ b/auto_sync_runner.php
@@ -1,0 +1,57 @@
+#!/usr/bin/env php
+<?php
+// Background worker for Auto Sync Playlist (#13).
+//
+// Performs one playlist sync out-of-process so the listener's ~1Hz tick
+// never blocks on the sync's HTTP round-trips (playlist GET + per-item
+// media-metadata GETs + the RF POST). An in-tick sync could stall FPP
+// status polling, viewer request handling, and the 30s heartbeat for the
+// full sync duration — 2026-07-16 release review, finding 1.
+//
+// Dispatched detached by remote_falcon_listener.php:
+//   php auto_sync_runner.php <playlistName> > /dev/null 2>&1 &
+// Logs directly to the listener log via logEntry(). Serialized by a
+// non-blocking flock: if a previous sync is still running, this pass skips
+// (the watcher fires again on the next playlist change).
+
+$skipJSsettings = true;
+// Buffer + suppress: common.php emits HTML and reads web-only $_SERVER keys
+// (see the identical dance at the top of remote_falcon_listener.php).
+ob_start();
+@include_once "/opt/fpp/www/common.php";
+ob_end_clean();
+
+require_once __DIR__ . '/lib/listener_log.php';
+require_once __DIR__ . '/lib/listener_http.php';
+require_once __DIR__ . '/lib/sync_builder.php';
+require_once __DIR__ . '/commands/_lib.php';
+
+$pluginName = basename(__DIR__);
+$logFile = $settings['logDirectory'] . "/" . $pluginName . "-listener.log";
+
+$playlistName = isset($argv[1]) ? $argv[1] : '';
+if ($playlistName === '') {
+    logEntry("ERROR - Auto Sync runner: no playlist name given");
+    exit(1);
+}
+
+$lockPath = sys_get_temp_dir() . '/remote-falcon-auto-sync.lock';
+$lock = @fopen($lockPath, 'c');
+if ($lock === false || !flock($lock, LOCK_EX | LOCK_NB)) {
+    logEntry("Auto Sync: previous sync still running; skipping this pass for '" . $playlistName . "'");
+    exit(0);
+}
+
+$cfg = rf_load_settings();
+if ($cfg === null || strlen($cfg['remoteToken']) <= 1) {
+    logEntry("ERROR - Auto Sync runner: remote token missing");
+    exit(1);
+}
+
+$result = rf_sync_playlist_to_rf($playlistName, $cfg);
+if ($result['ok']) {
+    logEntry("Auto Sync: synced " . $result['count'] . " items for '" . $playlistName . "'");
+} else {
+    logEntry("ERROR - Auto Sync failed for '" . $playlistName . "': " . $result['error']);
+    exit(1);
+}

--- a/commands/set_active_viewer_page.php
+++ b/commands/set_active_viewer_page.php
@@ -44,7 +44,10 @@ if ($result['body'] === null) {
 
 $decoded = json_decode($result['body'], true);
 $message = is_array($decoded) && isset($decoded['message']) ? $decoded['message'] : '';
-if ($result['status'] >= 200 && $result['status'] < 300 && $message === 'Success') {
+// A 2xx from this endpoint is definitionally success — the API's only
+// non-throwing path returns 200. Don't couple to the message wording
+// (2026-07-16 release review): a reworded success must not log as failure.
+if ($result['status'] >= 200 && $result['status'] < 300) {
     echo "Active viewer page set to '" . $pageName . "'\n";
 } else {
     // 4xx bodies (unknown page name, etc.) include the valid names, so the

--- a/js/remote_falcon_ui.js
+++ b/js/remote_falcon_ui.js
@@ -281,8 +281,12 @@ function hideSyncProgress() {
 async function syncPlaylistToRF() {
   if(REMOTE_TOKEN) {
     const selectedPlaylist = $('#remotePlaylistSelect').val();
+    if(!selectedPlaylist) {
+      $.jGrowl("Select a playlist to sync first", { themeState: 'danger' });
+      return;
+    }
     const shouldSyncMetadata = $('#autoSyncMetadataCheckbox').is(':checked');
-    updateSyncProgress('Syncing with Remote Falcon...', 40);
+    updateSyncProgress('Syncing with Remote Falcon... (large playlists can take a minute)', 40);
 
     try {
       // The payload (types, metadata, ordering) is built server-side by
@@ -309,6 +313,8 @@ async function syncPlaylistToRF() {
             message = "Playlist is Empty";
           } else if (body?.error === 'playlist_fetch_failed') {
             message = "Unable to load playlist";
+          } else if (body?.error === 'invalid_payload') {
+            message = "Select a playlist to sync first";
           }
         } catch (parseError) {
           // keep the generic message

--- a/remote_falcon_listener.php
+++ b/remote_falcon_listener.php
@@ -211,16 +211,19 @@ while(true) {
     $autoSyncEnabled = isset($pluginSettings['autoSyncPlaylist'])
         && urldecode($pluginSettings['autoSyncPlaylist']) === "true";
     if ($autoSyncEnabled && $remotePlaylist != "") {
+      $playlistDir = isset($settings['playlistDirectory']) ? $settings['playlistDirectory'] : '/home/fpp/media/playlists';
+      $playlistJson = $playlistDir . '/' . $remotePlaylist . '.json';
       if ($autoSyncPlaylistName !== $remotePlaylist) {
         // Synced playlist switched (UI or command) — start fresh, don't
-        // treat the new file's mtime as a pending change.
+        // treat the new file's mtime as a pending change. Log the watched
+        // path so a wrong playlistDirectory is visible in the first
+        // screenful of the log instead of failing silently.
         $autoSyncPlaylistName = $remotePlaylist;
         $autoSyncLastMtime = null;
         $autoSyncChangedAt = null;
         $autoSyncMissingWarned = false;
+        logEntry("Auto Sync: watching " . $playlistJson);
       }
-      $playlistDir = isset($settings['playlistDirectory']) ? $settings['playlistDirectory'] : '/home/fpp/media/playlists';
-      $playlistJson = $playlistDir . '/' . $remotePlaylist . '.json';
       $currMtime = @filemtime($playlistJson);
       if ($currMtime === false && !$autoSyncMissingWarned) {
         logEntry("WARNING - Auto Sync: playlist file not found: " . $playlistJson);
@@ -232,17 +235,13 @@ while(true) {
       $autoSyncLastMtime = $autoSyncDecision['lastMtime'];
       $autoSyncChangedAt = $autoSyncDecision['changedAt'];
       if ($autoSyncDecision['sync']) {
-        logEntry("Auto Sync: '" . $remotePlaylist . "' changed; re-syncing to Remote Falcon");
-        $autoSyncResult = rf_sync_playlist_to_rf($remotePlaylist, [
-          'remoteToken' => $remoteToken,
-          'pluginsApiPath' => $pluginsApiPath,
-          'raw' => $pluginSettings,
-        ]);
-        if ($autoSyncResult['ok']) {
-          logEntry("Auto Sync: synced " . $autoSyncResult['count'] . " items");
-        } else {
-          logEntry("ERROR - Auto Sync failed: " . $autoSyncResult['error']);
-        }
+        // Dispatch out-of-process so this ~1Hz tick never blocks on the
+        // sync's HTTP round-trips (an in-tick sync could stall status
+        // polling and the 30s heartbeat — 2026-07-16 release review). The
+        // runner logs its own outcome to this log and flock-serializes
+        // itself, so overlapping dispatches skip rather than stack.
+        logEntry("Auto Sync: '" . $remotePlaylist . "' changed; dispatching background sync");
+        exec("php " . escapeshellarg($pluginPath . "auto_sync_runner.php") . " " . escapeshellarg($remotePlaylist) . " > /dev/null 2>&1 &");
       }
     }
 

--- a/remote_falcon_ui.html
+++ b/remote_falcon_ui.html
@@ -2,7 +2,12 @@
 <html>
 <head>
   <link rel="stylesheet" type="text/css" href="./css/remote_falcon_ui.css">
-	<script src="./js/remote_falcon_ui.js"></script>
+	<!-- filemtime cache-buster: this page is include()d by FPP's plugin.php,
+	     so PHP executes here. Guarantees the browser picks up a new
+	     remote_falcon_ui.js on the first page load after a plugin upgrade —
+	     without it, a cached pre-#158 script could keep posting the legacy
+	     sync payload indefinitely (see sync_playlists.php). -->
+	<script src="./js/remote_falcon_ui.js?v=<?php echo @filemtime(__DIR__ . '/js/remote_falcon_ui.js'); ?>"></script>
 </head>
 <body>
 

--- a/sync_playlists.php
+++ b/sync_playlists.php
@@ -45,6 +45,10 @@ if (!is_array($input)) {
 }
 
 // Legacy pass-through: browser-built payload from a cached pre-#158 UI.
+// SUNSET: remote_falcon_ui.html now cache-busts the script by filemtime, so
+// this shape can only arrive from a tab loaded before the upgrade. Remove
+// this branch in the first release after 2026.07 (return invalid_payload;
+// the UI's generic error + a page reload recovers the user).
 if (isset($input['playlists']) && is_array($input['playlists'])) {
     $response = rf_http_request(
         'POST',

--- a/tests/integration/SyncOrchestratorTest.php
+++ b/tests/integration/SyncOrchestratorTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Integration tests for rf_sync_playlist_to_rf() — the effectful sync
+ * orchestrator in lib/sync_builder.php (fetch playlist from FPP → build the
+ * rich payload → POST to the RF plugins API). Closes the CLAUDE.md Layer 1/2
+ * gap flagged in the 2026-07-16 release review: the pure builder had unit
+ * tests but the orchestrator (and thus the wire behavior the auto-sync and
+ * command paths depend on) had none.
+ *
+ * Uses the standard two-MockServer harness: fppMock plays the local FPP API
+ * (playlist + media metadata), rfMock plays the RF plugins API and records
+ * the POSTed payload.
+ */
+final class SyncOrchestratorTest extends IntegrationTestCase {
+
+    private function cfg(array $raw = []): array {
+        return [
+            'remoteToken' => 'tok',
+            'pluginsApiPath' => $this->rfMock->getBaseUrl(),
+            'raw' => $raw,
+        ];
+    }
+
+    private function fppOpts(): array {
+        return ['fppBase' => $this->fppMock->getBaseUrl()];
+    }
+
+    public function testFullSync_postsRichPayloadWithMetadata(): void {
+        $this->fppMock->setRoute('/api/playlist/MyShow', [
+            'body' => [
+                'playlistInfo' => ['total_items' => 3],
+                'mainPlaylist' => [
+                    ['type' => 'both', 'sequenceName' => 'a.fseq', 'mediaName' => 'a.mp3', 'duration' => 30],
+                    ['type' => 'command', 'note' => 'Fog On', 'duration' => 1],
+                    ['type' => 'media', 'mediaName' => 'b.mp3', 'duration' => 200],
+                ],
+            ],
+        ]);
+        $this->fppMock->setRoute('/api/media/a.mp3/meta', [
+            'body' => ['format' => ['tags' => [
+                'title' => 'Song A',
+                'artist' => 'Artist A',
+                'comment' => '"https://x.com/a.png",',
+            ]]],
+        ]);
+        $this->rfMock->setRoute('/syncPlaylists', ['body' => ['message' => 'Success']]);
+
+        $result = rf_sync_playlist_to_rf('MyShow', $this->cfg(['autoSyncMetadata' => 'true']), $this->fppOpts());
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(3, $result['count']);
+
+        $recordings = $this->rfMock->getRecordings();
+        $this->assertCount(1, $recordings);
+        $rec = $recordings[0];
+        $this->assertSame('POST', $rec['method']);
+        $this->assertSame('tok', $rec['headers']['remotetoken'] ?? null);
+
+        $payload = json_decode($rec['body'], true);
+        $this->assertSame([
+            [
+                'playlistName' => 'a',
+                'playlistDuration' => 30,
+                'playlistIndex' => 1,
+                'playlistType' => 'SEQUENCE',
+                'mediaTitle' => 'Song A',
+                'mediaArtist' => 'Artist A',
+                'mediaAlbumUrl' => 'https://x.com/a.png',
+            ],
+            [
+                'playlistName' => 'Fog On',
+                'playlistDuration' => 0,
+                'playlistIndex' => 2,
+                'playlistType' => 'COMMAND',
+            ],
+            [
+                'playlistName' => 'b',
+                'playlistDuration' => 0,
+                'playlistIndex' => 3,
+                'playlistType' => 'MEDIA',
+            ],
+        ], $payload['playlists']);
+    }
+
+    public function testMetadataSettingOff_omitsMediaFields(): void {
+        $this->fppMock->setRoute('/api/playlist/MyShow', [
+            'body' => [
+                'mainPlaylist' => [
+                    ['type' => 'both', 'sequenceName' => 'a.fseq', 'mediaName' => 'a.mp3', 'duration' => 30],
+                ],
+            ],
+        ]);
+        $this->rfMock->setRoute('/syncPlaylists', ['body' => ['message' => 'Success']]);
+
+        // autoSyncMetadata unset in raw settings -> defaults to false; the
+        // media meta endpoint is deliberately NOT routed, so a fetch would 404
+        // and pollute the payload with empty fields if the flag leaked true.
+        $result = rf_sync_playlist_to_rf('MyShow', $this->cfg(), $this->fppOpts());
+
+        $this->assertTrue($result['ok']);
+        $payload = json_decode($this->rfMock->getRecordings()[0]['body'], true);
+        $this->assertArrayNotHasKey('mediaTitle', $payload['playlists'][0]);
+    }
+
+    public function testPlaylistFetchFailure_returnsErrorWithoutPosting(): void {
+        // No fpp route -> 404 -> playlist_fetch_failed, and RF must not be hit.
+        $result = rf_sync_playlist_to_rf('Ghost', $this->cfg(), $this->fppOpts());
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('playlist_fetch_failed', $result['error']);
+        $this->assertCount(0, $this->rfMock->getRecordings());
+    }
+
+    public function testEmptyPlaylist_returnsErrorWithoutPosting(): void {
+        $this->fppMock->setRoute('/api/playlist/Pauses', [
+            'body' => ['mainPlaylist' => [['type' => 'pause', 'duration' => 10]]],
+        ]);
+
+        $result = rf_sync_playlist_to_rf('Pauses', $this->cfg(), $this->fppOpts());
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('empty_playlist', $result['error']);
+        $this->assertCount(0, $this->rfMock->getRecordings());
+    }
+
+    public function testRfPostFailure_returnsSyncFailed(): void {
+        $this->fppMock->setRoute('/api/playlist/MyShow', [
+            'body' => ['mainPlaylist' => [['type' => 'sequence', 'sequenceName' => 'a.fseq', 'duration' => 30]]],
+        ]);
+        $this->rfMock->setRoute('/syncPlaylists', ['status' => 500, 'body' => 'oops']);
+
+        $result = rf_sync_playlist_to_rf('MyShow', $this->cfg(), $this->fppOpts());
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('sync_failed', $result['error']);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes from the pre-release code review (8 finder angles + adversarial verify over the combined #108/#109/#110 diff; 10 findings, 3 CONFIRMED-critical addressed here). PRs #108–110 merged while the review was running, so these land as one follow-up PR onto the release branch.

## Fixes
**Auto-sync (#13 follow-up) — the top CONFIRMED finding:**
- New `auto_sync_runner.php`: the sync now runs as a detached background process (flock-serialized, logs to the listener log). The ~1Hz listener tick no longer blocks on the sync's HTTP round-trips — an in-tick sync could stall FPP status polling, viewer request handling, and the 30s heartbeat (RF would mark the show offline).
- Listener logs the watched playlist path when the watcher (re)arms, so a wrong `playlistDirectory` is visible instead of silently never firing.

**Sync path (#158 follow-up):**
- `remote_falcon_ui.html` cache-busts the UI script by filemtime — closes the unbounded stale-JS window that kept the legacy `{playlists}` branch alive; that branch now carries an explicit sunset note (remove next release).
- JS: empty-selection guard before POST, `invalid_payload` mapped to an actionable message, progress copy warns large playlists take a minute.
- New `tests/integration/SyncOrchestratorTest.php` (5 tests): `rf_sync_playlist_to_rf` end-to-end against mock FPP + RF servers — closes the CLAUDE.md Layer-1/2 coverage gap.

**Page-switch command (#68 follow-up):**
- Any 2xx now counts as success (message used only for logging) — removes the brittle coupling to the literal `'Success'` string that would have logged reworded successes as failures.

## Not addressed (deliberate)
- MEDIA items sync with duration 0 (inherited from the UI path; now also on the command path) — product decision pending, affects only the Wrapped play-seconds stat.
- Delete+recreate playlist saves could baseline away one edit — follow-up issue material.

## Testing
Full suite green: 126 tests / 245 assertions (121 prior + 5 new orchestrator tests).