### PR TITLE
fix(plugin): FPP 10 registration — 10.0 versions entry + matrix coverage (#173)

### DIFF
--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -43,6 +43,17 @@
 		},
 		{
 			"minFPPVersion": "9.0",
+			"maxFPPVersion": "9.99",
+			"branch": "master",
+			"sha": "",
+			"dependencies": {
+				"plugins": [],
+				"packages": [],
+				"scripts": []
+			}
+		},
+		{
+			"minFPPVersion": "10.0",
 			"maxFPPVersion": "0",
 			"branch": "master",
 			"sha": "",

--- a/tests/PluginInfoTest.php
+++ b/tests/PluginInfoTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards pluginInfo.json against FPP Plugin Manager registration regressions.
+ *
+ * FPP 10 changed SelectPluginVersionIndices (www/plugins.php): an entry with
+ * maxFPPVersion "0" whose minFPPVersion major differs from the running major
+ * is capped at (curMajor - 1).999 and demoted to "untested". "0" no longer
+ * means "all future majors" — each new FPP major needs a versions[] entry
+ * whose min-major matches it. Issue #173: the 9.0 -> 0 entry left the plugin
+ * uninstallable on FPP 10.
+ *
+ * selectCompatible() below replicates that FPP 10 selection logic so the
+ * assertions fail the moment a supported FPP version loses coverage.
+ */
+class PluginInfoTest extends TestCase {
+
+    private function pluginInfo(): array {
+        $raw = file_get_contents(__DIR__ . '/../pluginInfo.json');
+        $data = json_decode($raw, true);
+        $this->assertIsArray($data, 'pluginInfo.json must be valid JSON');
+        return $data;
+    }
+
+    private static function isUnset($m): bool {
+        return $m === '0' || $m === '0.0' || $m === '' || $m === null;
+    }
+
+    /** Numeric segment-wise version compare, mirroring FPP's CompareFPPVersions. */
+    private static function compareVersions(string $a, string $b): int {
+        $as = array_map('intval', explode('.', $a));
+        $bs = array_map('intval', explode('.', $b));
+        for ($i = 0; $i < max(count($as), count($bs)); $i++) {
+            $av = $as[$i] ?? 0;
+            $bv = $bs[$i] ?? 0;
+            if ($av !== $bv) {
+                return $av <=> $bv;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Replica of FPP 10's SelectPluginVersionIndices for a given FPP version.
+     * Returns the selected versions[] entry, or null if none is compatible.
+     */
+    private static function selectCompatible(array $versions, string $fppVersion): ?array {
+        $curMajor = (int) explode('.', $fppVersion)[0];
+        $compatible = null;
+        foreach ($versions as $v) {
+            $effMax = $v['maxFPPVersion'];
+            if (self::isUnset($effMax)) {
+                $minMajor = (int) explode('.', (string) $v['minFPPVersion'])[0];
+                if ($minMajor !== $curMajor) {
+                    $effMax = ($curMajor - 1) . '.999';
+                }
+            }
+            $minOk = self::compareVersions((string) $v['minFPPVersion'], $fppVersion) <= 0;
+            $maxOk = self::isUnset($effMax) || self::compareVersions($effMax, $fppVersion) > 0;
+            if ($minOk && $maxOk) {
+                $compatible = $v;
+            }
+        }
+        return $compatible;
+    }
+
+    public function testEverySupportedFppVersionSelectsACompatibleEntry(): void {
+        $versions = $this->pluginInfo()['versions'];
+        foreach (['5.0', '6.3', '7.5', '8.2', '9.0', '9.4', '10.0', '10.1'] as $fpp) {
+            $entry = self::selectCompatible($versions, $fpp);
+            $this->assertNotNull($entry, "FPP $fpp has no compatible pluginInfo.json entry (plugin would show as untested/uninstallable)");
+            $this->assertSame('master', $entry['branch'], "FPP $fpp should install from master");
+        }
+    }
+
+    public function testCurrentFppMajorHasAMatchingMinMajorEntry(): void {
+        // The unbounded entry only survives FPP's untested-cap when its
+        // min-major equals the running major. When a new FPP major ships,
+        // this test's version list above must grow AND pluginInfo.json needs
+        // a matching entry — this assertion names the entry that must exist.
+        $versions = $this->pluginInfo()['versions'];
+        $unbounded = array_values(array_filter($versions, fn($v) => self::isUnset($v['maxFPPVersion'])));
+        $this->assertCount(1, $unbounded, 'Exactly one unbounded (maxFPPVersion "0") entry expected');
+        $this->assertSame('10.0', $unbounded[0]['minFPPVersion']);
+    }
+}

--- a/tests/docker/fpp-matrix.sh
+++ b/tests/docker/fpp-matrix.sh
@@ -29,11 +29,12 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_ROOT="$(cd "$HERE/../.." && pwd)"
 
 # Default matrix: latest stable of each major branch the plugin claims
-# to support. Per CLAUDE.md the plugin spans FPP 2.x-9.x; 4.x and earlier
+# to support. Per CLAUDE.md the plugin spans FPP 2.x-10.x; 4.x and earlier
 # docker images aren't readily available so we start with 5.x. Note that
 # 6.3.1 is a broken docker image (fppd never starts on launch); we use
-# 6.x-master for that slot instead.
-DEFAULT_VERSIONS=(5.5 6.x-master 7.5 8.4 9.4)
+# 6.x-master for that slot instead. FPP 10 has no stable docker tag yet,
+# so its slot rides 10.x-master until one ships.
+DEFAULT_VERSIONS=(5.5 6.x-master 7.5 8.4 9.5.3 10.x-master)
 read -ra VERSIONS <<< "${FPP_VERSIONS:-${DEFAULT_VERSIONS[*]}}"
 
 PORT=${PORT:-18080}


### PR DESCRIPTION
Fixes [issue #173](https://github.com/Remote-Falcon/remote-falcon-issue-tracker/issues/173): on FPP 10 the plugin is demoted to "untested" and drops out of the available-to-install list.

## Root cause

FPP 10's `SelectPluginVersionIndices` (`www/plugins.php`) no longer treats `maxFPPVersion: "0"` as "all future majors". An unbounded entry whose min-major differs from the running major is capped at `(curMajor-1).999` and flagged untested. Our newest entry was `9.0 -> 0`, so FPP 10 judged it incompatible. Verified against current FPP master source.

## Fix

`pluginInfo.json`:
- new entry `10.0 -> 0` (branch `master`) — min-major matches FPP 10, so the untested-cap never applies
- prior entry capped `9.0 -> 9.99` — FPP 9 selection unchanged

## Tests

- **`tests/PluginInfoTest.php`** — replicates FPP 10's selection logic (`SelectPluginVersionIndices` + `CompareFPPVersions`) and asserts every supported FPP version 5.0–10.1 selects a compatible `master` entry, plus pins the single unbounded entry's min-major so each new FPP major forces a deliberate update. Confirmed it fails against the old file.
- **`tests/docker/fpp-matrix.sh`** — permanent `10.x-master` slot (no stable FPP 10 docker tag yet) and 9.x slot bumped to latest stable 9.5.3.
- **Live matrix run on this branch:** FPP 9.5.3 → 19/19 pass, FPP 10.x-master (PHP 8.4.16) → 19/19 pass (install, all command registrations, settings round-trip, listener boot, Restart Listener via /api/command).

## Follow-up (out of repo)

FPP's master plugin list (`FalconChristmas/fpp-pluginList`) still registers us via `whitesoup12/remote-falcon-plugin`, so this fix only reaches users once that entry is repointed to the canonical repo (upstream PR in progress) or the fork syncs.